### PR TITLE
Add configurable window width, and possibility to hide the terminal window

### DIFF
--- a/lua/dap-view/actions.lua
+++ b/lua/dap-view/actions.lua
@@ -58,10 +58,25 @@ M.open = function()
 
     local config = setup.config
 
+    -- Calculate the window width based on parent window and
+    -- configuration. Numbers between 0 and 1 are interpreted
+    -- as a percentage.
+    local win_width = 0.5
+
+    if config.windows.width > 1 then
+        win_width = config.windows.width
+    end
+
+    if config.windows.width <= 1 then
+        local parent_width = vim.api.nvim_win_get_width(0)
+        win_width = math.floor(parent_width * config.windows.width)
+    end
+
     local winnr = api.nvim_open_win(bufnr, false, {
         split = "right",
         win = term_winnr,
         height = config.windows.height,
+        width = win_width,
     })
 
     assert(winnr ~= 0, "Failed to create dap-view window")

--- a/lua/dap-view/actions.lua
+++ b/lua/dap-view/actions.lua
@@ -38,6 +38,41 @@ M.close = function()
     end
 end
 
+-- Calculate the window width based on parent window and
+-- configuration. Numbers between 0 and 1 are interpreted
+-- as a percentage.
+local function get_window_size(config)
+    local win_width = 0.5
+
+    local parent_width = vim.api.nvim_win_get_width(0)
+    if config.windows.width > 1 then
+        win_width = config.windows.width
+    end
+
+    if config.windows.width < 1 then
+        win_width = math.floor(parent_width * config.windows.width)
+    end
+
+    if config.windows.width == 1 then
+        win_width = parent_width
+    end
+
+    return win_width
+end
+
+-- If the window should be 100% width, we have already hidden
+-- the terminal and should split below. If the terminal window
+-- is open we should split to the right of it.
+local function get_window_split(config)
+    local split = "right"
+
+    if config.windows.width == 1 then
+        split = "below"
+    end
+
+    return split
+end
+
 M.open = function()
     M.close()
 
@@ -58,25 +93,11 @@ M.open = function()
 
     local config = setup.config
 
-    -- Calculate the window width based on parent window and
-    -- configuration. Numbers between 0 and 1 are interpreted
-    -- as a percentage.
-    local win_width = 0.5
-
-    if config.windows.width > 1 then
-        win_width = config.windows.width
-    end
-
-    if config.windows.width <= 1 then
-        local parent_width = vim.api.nvim_win_get_width(0)
-        win_width = math.floor(parent_width * config.windows.width)
-    end
-
     local winnr = api.nvim_open_win(bufnr, false, {
-        split = "right",
+        split = get_window_split(config),
         win = term_winnr,
         height = config.windows.height,
-        width = win_width,
+        width = get_window_size(config),
     })
 
     assert(winnr ~= 0, "Failed to create dap-view window")

--- a/lua/dap-view/actions.lua
+++ b/lua/dap-view/actions.lua
@@ -60,19 +60,6 @@ local function get_window_size(config)
     return win_width
 end
 
--- If the window should be 100% width, we have already hidden
--- the terminal and should split below. If the terminal window
--- is open we should split to the right of it.
-local function get_window_split(config)
-    local split = "right"
-
-    if config.windows.width == 1 then
-        split = "below"
-    end
-
-    return split
-end
-
 M.open = function()
     M.close()
 
@@ -94,7 +81,7 @@ M.open = function()
     local config = setup.config
 
     local winnr = api.nvim_open_win(bufnr, false, {
-        split = get_window_split(config),
+        split = config.windows.position,
         win = term_winnr,
         height = config.windows.height,
         width = get_window_size(config),

--- a/lua/dap-view/config.lua
+++ b/lua/dap-view/config.lua
@@ -8,6 +8,7 @@ local M = {}
 
 ---@class WindowsConfig
 ---@field height integer
+---@field width number|integer Width of the window in either characters or percentage (as decimal: 0.75)
 
 --- @alias SectionType '"breakpoints"' | '"exceptions"' | '"watches"' | '"repl"'
 
@@ -22,6 +23,7 @@ M.config = {
     },
     windows = {
         height = 12,
+        width = 0.5,
     },
 }
 

--- a/lua/dap-view/config.lua
+++ b/lua/dap-view/config.lua
@@ -8,7 +8,7 @@ local M = {}
 
 ---@class WindowsConfig
 ---@field height integer
----@field width number|integer Width of the window in either characters or percentage (as decimal: 0.75)
+---@field width number|integer Width of the window in either characters or percentage (as decimal: 0.75). Window size of 1 means 100% width, which will hide the terminal window.
 
 --- @alias SectionType '"breakpoints"' | '"exceptions"' | '"watches"' | '"repl"'
 

--- a/lua/dap-view/config.lua
+++ b/lua/dap-view/config.lua
@@ -9,6 +9,7 @@ local M = {}
 ---@class WindowsConfig
 ---@field height integer
 ---@field width number|integer Width of the window in either characters or percentage (as decimal: 0.75). Window size of 1 means 100% width, which will hide the terminal window.
+---@field position string By default the dap-view window will be opened to the right of the terminal. Should be left, right, above or below.
 
 --- @alias SectionType '"breakpoints"' | '"exceptions"' | '"watches"' | '"repl"'
 
@@ -24,6 +25,7 @@ M.config = {
     windows = {
         height = 12,
         width = 0.5,
+        position = "right",
     },
 }
 

--- a/lua/dap-view/term/init.lua
+++ b/lua/dap-view/term/init.lua
@@ -46,6 +46,10 @@ M.term_buf_win_init = function()
 
         util_buf.quit_buf_autocmd(state.term_bufnr, M.close_term_buf_win)
 
+        if config.windows.width == 1 then
+            vim.api.nvim_win_hide(state.term_winnr)
+        end
+
         dap.defaults.fallback.terminal_win_cmd = function()
             return state.term_bufnr, state.term_winnr
         end


### PR DESCRIPTION
I never use the terminal window when debugging, so having it open and taking half the window size is a waste of space for me. This PR adds the option to change the size of the `nvim-dap-view` window:

`require("dap-view").setup({windows = { width = 0.75 }}) `

Width is set to a percentage if the number is between 0 and 1, and otherwise it is set to number of columns. If the width is set to 1 it means 100%. This will use `nvim_win_hide` to hide the terminal window from view. The default is set to 0.5 which emulates the existing behaviour.

There is a comment in `term_buf_win_init` about not _closing_ the term buffer, but I think hiding the window should be fine.