### PR TITLE
fix(DapViewWatch): switch to Watcher view when repl active

### DIFF
--- a/lua/dap-view/actions.lua
+++ b/lua/dap-view/actions.lua
@@ -84,16 +84,13 @@ M.add_expr = function()
     local expression = expr.eval_expression()
     require("dap-view.watches.actions").add_watch_expr(expression)
 
+    -- If repl view is selected we need to set current buf to "watchers"
     if state.current_section == "repl" then
-        local winnr = vim.api.nvim_get_current_win()
-        vim.api.nvim_set_current_win(state.winnr)
-        require("dap-view.views").switch(function()
-            require("dap-view.watches.view").show()
+        api.nvim_win_call(state.winnr, function()
+            api.nvim_set_current_buf(state.bufnr)
         end)
-        vim.api.nvim_set_current_win(winnr)
-    else
-        require("dap-view.watches.view").show()
     end
+    require("dap-view.watches.view").show()
 end
 
 return M

--- a/lua/dap-view/actions.lua
+++ b/lua/dap-view/actions.lua
@@ -84,13 +84,16 @@ M.add_expr = function()
     local expression = expr.eval_expression()
     require("dap-view.watches.actions").add_watch_expr(expression)
 
-    -- If repl view is selected we need to set current buf to "watchers"
-    if state.current_section == "repl" then
-        api.nvim_win_call(state.winnr, function()
-            api.nvim_set_current_buf(state.bufnr)
-        end)
+    -- Only show watches view if window is valid
+    if state.winnr and api.nvim_win_is_valid(state.winnr) then
+        -- If repl view is selected we need to set current buf to "watchers"
+        if state.current_section == "repl" then
+            api.nvim_win_call(state.winnr, function()
+                api.nvim_set_current_buf(state.bufnr)
+            end)
+        end
+        require("dap-view.watches.view").show()
     end
-    require("dap-view.watches.view").show()
 end
 
 return M

--- a/lua/dap-view/actions.lua
+++ b/lua/dap-view/actions.lua
@@ -84,16 +84,7 @@ M.add_expr = function()
     local expression = expr.eval_expression()
     require("dap-view.watches.actions").add_watch_expr(expression)
 
-    -- Only show watches view if window is valid
-    if state.winnr and api.nvim_win_is_valid(state.winnr) then
-        -- If repl view is selected we need to set current buf to "watchers"
-        if state.current_section == "repl" then
-            api.nvim_win_call(state.winnr, function()
-                api.nvim_set_current_buf(state.bufnr)
-            end)
-        end
-        require("dap-view.watches.view").show()
-    end
+    require("dap-view.views").switch(require("dap-view.watches.view").show)
 end
 
 return M

--- a/lua/dap-view/actions.lua
+++ b/lua/dap-view/actions.lua
@@ -82,10 +82,18 @@ end
 
 M.add_expr = function()
     local expression = expr.eval_expression()
-
     require("dap-view.watches.actions").add_watch_expr(expression)
 
-    require("dap-view.watches.view").show()
+    if state.current_section == "repl" then
+        local winnr = vim.api.nvim_get_current_win()
+        vim.api.nvim_set_current_win(state.winnr)
+        require("dap-view.views").switch(function()
+            require("dap-view.watches.view").show()
+        end)
+        vim.api.nvim_set_current_win(winnr)
+    else
+        require("dap-view.watches.view").show()
+    end
 end
 
 return M

--- a/lua/dap-view/breakpoints/actions.lua
+++ b/lua/dap-view/breakpoints/actions.lua
@@ -58,7 +58,7 @@ M._jump_to_breakpoint = function()
         if bufnr == -1 then
             vim.cmd("buffer " .. abs_path)
         else
-            vim.cmd("buffer " .. bufnr)
+            api.nvim_set_current_buf(bufnr)
         end
     end)
 

--- a/lua/dap-view/options/winbar.lua
+++ b/lua/dap-view/options/winbar.lua
@@ -9,9 +9,7 @@ local winbar_info = {
         keymap = "B",
         action = function()
             if vim.tbl_contains(setup.config.winbar.sections, "breakpoints") then
-                require("dap-view.views").switch(function()
-                    require("dap-view.breakpoints.view").show()
-                end)
+                require("dap-view.views").switch(require("dap-view.breakpoints.view").show)
             end
         end,
     },
@@ -20,9 +18,7 @@ local winbar_info = {
         keymap = "E",
         action = function()
             if vim.tbl_contains(setup.config.winbar.sections, "exceptions") then
-                require("dap-view.views").switch(function()
-                    require("dap-view.exceptions.view").show()
-                end)
+                require("dap-view.views").switch(require("dap-view.exceptions.view").show)
             end
         end,
     },
@@ -31,9 +27,7 @@ local winbar_info = {
         keymap = "W",
         action = function()
             if vim.tbl_contains(setup.config.winbar.sections, "watches") then
-                require("dap-view.views").switch(function()
-                    require("dap-view.watches.view").show()
-                end)
+                require("dap-view.views").switch(require("dap-view.watches.view").show)
             end
         end,
     },

--- a/lua/dap-view/views/init.lua
+++ b/lua/dap-view/views/init.lua
@@ -27,9 +27,14 @@ M.cleanup_view = function(cond, message)
 end
 
 local switch_to_dapview_buf = function()
+    if not (state.winnr and api.nvim_win_is_valid(state.winnr)) then
+        return
+    end
     -- The REPL is actually another buffer
     if state.current_section == "repl" then
-        api.nvim_set_current_buf(state.bufnr)
+        api.nvim_win_call(state.winnr, function()
+            api.nvim_set_current_buf(state.bufnr)
+        end)
     end
 end
 

--- a/lua/dap-view/views/init.lua
+++ b/lua/dap-view/views/init.lua
@@ -29,7 +29,7 @@ end
 local switch_to_dapview_buf = function()
     -- The REPL is actually another buffer
     if state.current_section == "repl" then
-        vim.cmd("buffer " .. state.bufnr)
+        api.nvim_set_current_buf(state.bufnr)
     end
 end
 


### PR DESCRIPTION
Fixes issue where when using `DapViewWatch` if repl is active the Watcher view does not get filled with watcher expressions