### PR TITLE
feat: switchbuf option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
         - [Recommended Setup](#recommended-setup)
             - [Automatic Toggle](#automatic-toggle)
             - [Hide Terminal](#hide-terminal)
-            - [Terminal Position and Integration](#terminal-position-and-integration)
+            - [Jumping](#jumping)
             - [Expanding Variables](#expanding-variables)
         - [Highlight Groups](#highlight-groups)
         - [Filetypes and autocommands](#filetypes-and-autocommands)
@@ -149,6 +149,8 @@ return {
             start_hidden = false,
         },
     },
+    -- Controls how to jump when selecting a breakpoint or navigating the stack
+    switchbuf = "usetab,newtab",
 }
 ```
 
@@ -241,7 +243,7 @@ Some debug adapters don't use the integrated terminal (console). To avoid having
 
 ```lua
 -- Goes into your opts table (if using lazy.nvim), otherwise goes into the setup function
--- No need to include the "return" statement (or the outer curly braces)
+-- No need to include the "return" statement
 return {
     windows = {
         terminal = {
@@ -254,21 +256,23 @@ return {
 }
 ```
 
-#### Terminal Position and Integration
+#### Jumping
 
-When setting `windows.terminal.position` to `right` the views window may be used
-to display the current breakpoint because `nvim-dap` defaults to the global
-`switchbuf` setting.  A common solution is to set `switchbuf` to "useopen":
+When setting `windows.terminal.position` to `right`, `nvim-dap-view`'s main window may be used to display the current frame (after execution stops), because `nvim-dap` defaults to the global `switchbuf` setting. To address this, update your `switchbuf` configuration. For instance:
 
 ```lua
-require("dap").defaults.fallback.switchbuf = "useopen"
+require("dap").defaults.fallback.switchbuf = "useopen" -- See :h dap-defaults to learn more
 ```
 
-If you are using an adapter that does not natively support the `nvim-dap` integrated
-terminal, but you want to use the `nvim-dap-view` terminal anyway, you can get
-the `winnr` and `bufnr` of the `nvim-dap-view` terminal via `dap-view.state` and
-use `vim.fn.jobstart` to start your debug adapter in the `nvim-dap-view` terminal!
-An example can be found [here](https://github.com/catgoose/nvim/blob/ffd88fd66ade9cad0da934e10308dbbfc76b9540/lua/config/dap/go.lua#L19-L48)
+When jumping via `nvim-dap-view` (to a breakpoint or to a frame in the stack), `nvim-dap-view` uses its own `switchbuf`, which supports a subset of the default neovim options ("newtab", "useopen", "usetab" and "uselast"). You can customize it with:
+
+```lua
+-- Goes into your opts table (if using lazy.nvim), otherwise goes into the setup function
+-- No need to include the "return" statement
+return {
+    switchbuf = "useopen",
+}
+```
 
 #### Expanding Variables
 

--- a/lua/dap-view/config.lua
+++ b/lua/dap-view/config.lua
@@ -19,6 +19,7 @@ local M = {}
 ---@class Config
 ---@field winbar WinbarConfig
 ---@field windows WindowsConfig
+---@field switchbuf string
 M.config = {
     winbar = {
         show = true,
@@ -33,6 +34,7 @@ M.config = {
             start_hidden = false,
         },
     },
+    switchbuf = "usetab,newtab",
 }
 
 return M

--- a/lua/dap-view/setup/validate/init.lua
+++ b/lua/dap-view/setup/validate/init.lua
@@ -5,6 +5,7 @@ function M.validate(config)
     require("dap-view.setup.validate.util").validate("config", {
         windows = { config.windows, "table" },
         winbar = { config.winbar, "table" },
+        switchbuf = { config.switchbuf, "string" },
     }, config)
 
     require("dap-view.setup.validate.winbar").validate(config.winbar)

--- a/lua/dap-view/threads/view.lua
+++ b/lua/dap-view/threads/view.lua
@@ -42,7 +42,7 @@ M.show = function()
                 :filter(
                     ---@param f dap.StackFrame
                     function(f)
-                        return f.source and f.source.path and vim.uv.fs_stat(f.source.path) or false
+                        return (f.source and f.source.path and vim.uv.fs_stat(f.source.path) ~= nil) or false
                     end
                 )
                 :totable()

--- a/lua/dap-view/views/util.lua
+++ b/lua/dap-view/views/util.lua
@@ -36,14 +36,16 @@ M.jump_to_location = function(pattern, column)
 
     local bufnr = vim.uri_to_bufnr(vim.uri_from_fname(abs_path))
 
-    local switchbufopt = require("dap").defaults.fallback.switchbuf or vim.go.switchbuf
+    local config = setup.config
+
+    local switchbufopt = config.switchbuf
     local win = window.get_win_respecting_switchbuf(switchbufopt, bufnr)
 
     if not win then
         win = api.nvim_open_win(0, true, {
             split = "above",
             win = -1,
-            height = vim.o.lines - setup.config.windows.height,
+            height = vim.o.lines - config.windows.height,
         })
     end
 

--- a/lua/dap-view/views/util.lua
+++ b/lua/dap-view/views/util.lua
@@ -1,4 +1,5 @@
 local setup = require("dap-view.setup")
+local window = require("dap-view.views.windows")
 
 local M = {}
 
@@ -33,36 +34,26 @@ M.jump_to_location = function(pattern, column)
         return
     end
 
-    local windows = api.nvim_tabpage_list_wins(0)
+    local bufnr = vim.uri_to_bufnr(vim.uri_from_fname(abs_path))
 
-    -- TODO this simply finds the first suitable window
-    -- A better approach could try to match the paths to avoid jumping around
-    -- Or perhaps there's a way to respect the 'switchbuf' option
-    local prev_or_new_window = vim.iter(windows)
-        :filter(function(w)
-            local bufnr = api.nvim_win_get_buf(w)
-            return vim.bo[bufnr].buftype == ""
-        end)
-        :find(function(w)
-            return w
-        end)
+    local switchbufopt = require("dap").defaults.fallback.switchbuf or vim.go.switchbuf
+    local win = window.get_win_respecting_switchbuf(switchbufopt, bufnr)
 
-    if not prev_or_new_window then
-        prev_or_new_window = api.nvim_open_win(0, true, {
+    if not win then
+        win = api.nvim_open_win(0, true, {
             split = "above",
             win = -1,
             height = vim.o.lines - setup.config.windows.height,
         })
     end
 
-    api.nvim_win_call(prev_or_new_window, function()
-        local bufnr = vim.uri_to_bufnr(vim.uri_from_fname(abs_path))
+    api.nvim_win_call(win, function()
         api.nvim_set_current_buf(bufnr)
     end)
 
-    api.nvim_win_set_cursor(prev_or_new_window, { line_num, column or 0 })
+    api.nvim_win_set_cursor(win, { line_num, column or 0 })
 
-    api.nvim_set_current_win(prev_or_new_window)
+    api.nvim_set_current_win(win)
 end
 
 return M

--- a/lua/dap-view/views/windows/init.lua
+++ b/lua/dap-view/views/windows/init.lua
@@ -1,0 +1,35 @@
+local switchbuf = require("dap-view.views.windows.switchbuf")
+
+local M = {}
+
+local api = vim.api
+
+---@param switchbufopt string
+---@param bufnr integer
+M.get_win_respecting_switchbuf = function(switchbufopt, bufnr)
+    local winnr = api.nvim_get_current_win()
+
+    local switchbuf_winfn = switchbuf.switchbuf_winfn
+
+    if switchbufopt:find("usetab") then
+        switchbuf_winfn.useopen = switchbuf_winfn.usetab
+    end
+
+    if switchbufopt:find("newtab") then
+        switchbuf_winfn.vsplit = switchbuf_winfn.newtab
+        switchbuf_winfn.split = switchbuf_winfn.newtab
+    end
+
+    local opts = vim.split(switchbufopt, ",", { plain = true })
+    for _, opt in pairs(opts) do
+        local winfn = switchbuf.switchbuf_winfn[opt]
+        if winfn then
+            local win = winfn(bufnr, winnr)
+            if win then
+                return win
+            end
+        end
+    end
+end
+
+return M

--- a/lua/dap-view/views/windows/init.lua
+++ b/lua/dap-view/views/windows/init.lua
@@ -15,11 +15,6 @@ M.get_win_respecting_switchbuf = function(switchbufopt, bufnr)
         switchbuf_winfn.useopen = switchbuf_winfn.usetab
     end
 
-    if switchbufopt:find("newtab") then
-        switchbuf_winfn.vsplit = switchbuf_winfn.newtab
-        switchbuf_winfn.split = switchbuf_winfn.newtab
-    end
-
     local opts = vim.split(switchbufopt, ",", { plain = true })
     for _, opt in pairs(opts) do
         local winfn = switchbuf.switchbuf_winfn[opt]

--- a/lua/dap-view/views/windows/switchbuf.lua
+++ b/lua/dap-view/views/windows/switchbuf.lua
@@ -1,0 +1,114 @@
+local M = {}
+
+local api = vim.api
+
+local get_prev_win = function()
+    local windows = api.nvim_tabpage_list_wins(0)
+
+    return vim.iter(windows):find(function(w)
+        local bufnr = api.nvim_win_get_buf(w)
+        return vim.bo[bufnr].buftype == ""
+    end)
+end
+
+---@type table<string, fun(bufnr?: integer, winnr?: integer, line?: integer): integer?>
+M.switchbuf_winfn = {}
+
+M.switchbuf_winfn.split = function()
+    local prev_win = get_prev_win()
+
+    return api.nvim_open_win(0, true, {
+        split = "below",
+        win = prev_win or 0,
+    })
+end
+
+M.switchbuf_winfn.vsplit = function()
+    local prev_win = get_prev_win()
+
+    return api.nvim_open_win(0, true, {
+        split = "right",
+        win = prev_win or 0,
+    })
+end
+
+M.switchbuf_winfn.newtab = function()
+    -- Can't create a new tab with lua API
+    -- https://github.com/neovim/neovim/pull/27223
+    vim.cmd.tabnew()
+    return api.nvim_get_current_win()
+end
+
+M.switchbuf_winfn.useopen = function(bufnr, winnr)
+    if api.nvim_win_get_buf(winnr) == bufnr then
+        return winnr
+    end
+
+    local windows = api.nvim_tabpage_list_wins(0)
+
+    for _, win in ipairs(windows) do
+        if api.nvim_win_get_buf(win) == bufnr then
+            return win
+        end
+    end
+
+    return nil
+end
+
+M.switchbuf_winfn.usetab = function(bufnr, winnr)
+    if api.nvim_win_get_buf(winnr) == bufnr then
+        return winnr
+    end
+
+    local tabs = { 0 }
+
+    vim.list_extend(tabs, api.nvim_list_tabpages())
+
+    for _, tabpage in ipairs(tabs) do
+        for _, win in ipairs(api.nvim_tabpage_list_wins(tabpage)) do
+            if api.nvim_win_get_buf(win) == bufnr then
+                api.nvim_set_current_tabpage(tabpage)
+                return win
+            end
+        end
+    end
+
+    return nil
+end
+
+M.switchbuf_winfn.tabusevisible = function(bufnr, winnr, line)
+    local cur_tab = api.nvim_win_get_tabpage(winnr)
+
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(cur_tab)) do
+        if api.nvim_win_get_buf(win) == bufnr then
+            local first = vim.fn.line("w0", win)
+            local last = vim.fn.line("w$", win)
+            if first <= line and line <= last then
+                return win
+            end
+        end
+    end
+
+    return nil
+end
+
+M.switchbuf_winfn.uselast = function(_, winnr)
+    local cur_buf = api.nvim_get_current_buf()
+
+    local ok, is_source_buf = pcall(vim.api.nvim_buf_get_var, cur_buf, "dap_source_buf")
+
+    is_source_buf = ok and is_source_buf
+
+    if vim.bo[cur_buf].buftype == "" or is_source_buf then
+        return winnr
+    else
+        local win = vim.fn.win_getid(vim.fn.winnr("#"))
+        if win then
+            return win
+        end
+
+        return nil
+    end
+end
+
+return M

--- a/lua/dap-view/views/windows/switchbuf.lua
+++ b/lua/dap-view/views/windows/switchbuf.lua
@@ -52,11 +52,7 @@ end
 M.switchbuf_winfn.uselast = function(_, winnr)
     local cur_buf = api.nvim_get_current_buf()
 
-    local ok, is_source_buf = pcall(vim.api.nvim_buf_get_var, cur_buf, "dap_source_buf")
-
-    is_source_buf = ok and is_source_buf
-
-    if vim.bo[cur_buf].buftype == "" or is_source_buf then
+    if vim.bo[cur_buf].buftype == "" then
         return winnr
     else
         local win = vim.fn.win_getid(vim.fn.winnr("#"))

--- a/lua/dap-view/views/windows/switchbuf.lua
+++ b/lua/dap-view/views/windows/switchbuf.lua
@@ -2,35 +2,8 @@ local M = {}
 
 local api = vim.api
 
-local get_prev_win = function()
-    local windows = api.nvim_tabpage_list_wins(0)
-
-    return vim.iter(windows):find(function(w)
-        local bufnr = api.nvim_win_get_buf(w)
-        return vim.bo[bufnr].buftype == ""
-    end)
-end
-
 ---@type table<string, fun(bufnr?: integer, winnr?: integer, line?: integer): integer?>
 M.switchbuf_winfn = {}
-
-M.switchbuf_winfn.split = function()
-    local prev_win = get_prev_win()
-
-    return api.nvim_open_win(0, true, {
-        split = "below",
-        win = prev_win or 0,
-    })
-end
-
-M.switchbuf_winfn.vsplit = function()
-    local prev_win = get_prev_win()
-
-    return api.nvim_open_win(0, true, {
-        split = "right",
-        win = prev_win or 0,
-    })
-end
 
 M.switchbuf_winfn.newtab = function()
     -- Can't create a new tab with lua API

--- a/lua/dap-view/views/windows/switchbuf.lua
+++ b/lua/dap-view/views/windows/switchbuf.lua
@@ -49,22 +49,6 @@ M.switchbuf_winfn.usetab = function(bufnr, winnr)
     return nil
 end
 
-M.switchbuf_winfn.tabusevisible = function(bufnr, winnr, line)
-    local cur_tab = api.nvim_win_get_tabpage(winnr)
-
-    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(cur_tab)) do
-        if api.nvim_win_get_buf(win) == bufnr then
-            local first = vim.fn.line("w0", win)
-            local last = vim.fn.line("w$", win)
-            if first <= line and line <= last then
-                return win
-            end
-        end
-    end
-
-    return nil
-end
-
 M.switchbuf_winfn.uselast = function(_, winnr)
     local cur_buf = api.nvim_get_current_buf()
 


### PR DESCRIPTION
Closes #29 

## TODO

- Default `switchbuf` variations:
  - `split` ⇾ would split dap-view's window (awkward)
  - `vsplit` ⇾ would (v)split dap-view's window (awkward)
  - [x] `newtab`
  - [x] `useopen`
  - [x] `usetab`
  - [x] `uselast` ⇾ also a bit awkward, but I can see this being used

- nvim-dap's extensions
  - `usevisible` ⇾ wouldn't work with dap-view's window

We could use the last window for the `split` / `vsplit` /  `usevisible` variations (though, of course, that does not match the default behavior and therefore should be documented).