### PR TITLE
feat(winbar): configurable header labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ return {
         sections = { "watches", "scopes", "exceptions", "breakpoints", "threads", "repl" },
         -- Must be one of the sections declared above
         default_section = "watches",
+        headers = {
+            breakpoints = "Breakpoints [B]",
+            scopes = "Scopes [S]",
+            exceptions = "Exceptions [E]",
+            watches = "Watches [W]",
+            threads = "Threads [T]",
+            repl = "REPL [R]",
+            console = "Console [C]",
+        },
     },
     windows = {
         height = 12,

--- a/lua/dap-view/config.lua
+++ b/lua/dap-view/config.lua
@@ -4,6 +4,16 @@ local M = {}
 ---@field sections SectionType[]
 ---@field default_section SectionType
 ---@field show boolean
+---@field headers WinbarHeaders Header label for each section.
+
+---@class WinbarHeaders
+---@field breakpoints string
+---@field scopes string
+---@field exceptions string
+---@field watches string
+---@field threads string
+---@field repl string
+---@field console string
 
 ---@class TerminalConfig
 ---@field hide string[] Hide the terminal for listed adapters.
@@ -26,6 +36,15 @@ M.config = {
         show = true,
         sections = { "watches", "scopes", "exceptions", "breakpoints", "threads", "repl" },
         default_section = "watches",
+        headers = {
+            breakpoints = "Breakpoints [B]",
+            scopes = "Scopes [S]",
+            exceptions = "Exceptions [E]",
+            watches = "Watches [W]",
+            threads = "Threads [T]",
+            repl = "REPL [R]",
+            console = "Console [C]",
+        },
     },
     windows = {
         height = 12,

--- a/lua/dap-view/options/winbar.lua
+++ b/lua/dap-view/options/winbar.lua
@@ -7,7 +7,6 @@ local api = vim.api
 
 local winbar_info = {
     breakpoints = {
-        desc = "Breakpoints [B]",
         keymap = "B",
         action = function()
             if vim.tbl_contains(setup.config.winbar.sections, "breakpoints") then
@@ -16,7 +15,6 @@ local winbar_info = {
         end,
     },
     scopes = {
-        desc = "Scopes [S]",
         keymap = "S",
         action = function()
             if vim.tbl_contains(setup.config.winbar.sections, "scopes") then
@@ -25,7 +23,6 @@ local winbar_info = {
         end,
     },
     exceptions = {
-        desc = "Exceptions [E]",
         keymap = "E",
         action = function()
             if vim.tbl_contains(setup.config.winbar.sections, "exceptions") then
@@ -34,7 +31,6 @@ local winbar_info = {
         end,
     },
     watches = {
-        desc = "Watches [W]",
         keymap = "W",
         action = function()
             if vim.tbl_contains(setup.config.winbar.sections, "watches") then
@@ -43,7 +39,6 @@ local winbar_info = {
         end,
     },
     threads = {
-        desc = "Threads [T]",
         keymap = "T",
         action = function()
             if vim.tbl_contains(setup.config.winbar.sections, "threads") then
@@ -52,7 +47,6 @@ local winbar_info = {
         end,
     },
     repl = {
-        desc = "REPL [R]",
         keymap = "R",
         action = function()
             if vim.tbl_contains(setup.config.winbar.sections, "repl") then
@@ -66,7 +60,6 @@ local winbar_info = {
         end,
     },
     console = {
-        desc = "Console [C]", -- T was taken
         keymap = "C",
         action = function()
             if vim.tbl_contains(setup.config.winbar.sections, "console") then
@@ -115,11 +108,8 @@ local set_winbar_opt = function(selected_section)
             local info = winbar_info[key]
 
             if info ~= nil then
-                local desc = "%"
-                    .. idx
-                    .. "@v:lua.require'dap-view.options.winbar'.on_click@ "
-                    .. info.desc
-                    .. " %T"
+                local desc = setup.config.winbar.headers[key]
+                desc = "%" .. idx .. "@v:lua.require'dap-view.options.winbar'.on_click@ " .. desc .. " %T"
 
                 if selected_section == key then
                     desc = "%#TabLineSel#" .. desc

--- a/lua/dap-view/setup/validate/winbar.lua
+++ b/lua/dap-view/setup/validate/winbar.lua
@@ -2,11 +2,24 @@ local M = {}
 
 ---@param config WinbarConfig
 function M.validate(config)
-    require("dap-view.setup.validate.util").validate("winbar", {
+    local validate = require("dap-view.setup.validate.util").validate
+
+    validate("winbar", {
         show = { config.show, "boolean" },
         sections = { config.sections, "table" },
         default_section = { config.default_section, "string" },
+        headers = { config.headers, "table" },
     }, config)
+
+    validate("winbar.headers", {
+        breakpoints = { config.headers.breakpoints, "string" },
+        scopes = { config.headers.scopes, "string" },
+        exceptions = { config.headers.exceptions, "string" },
+        watches = { config.headers.watches, "string" },
+        threads = { config.headers.threads, "string" },
+        repl = { config.headers.repl, "string" },
+        console = { config.headers.console, "string" },
+    }, config.headers)
 
     local sections = config.sections
     local default = config.default_section


### PR DESCRIPTION
This PR makes headers configurable.

It allows simply changing the header to match your preference like this:
```lua
winbar = {
  headers = {
    breakpoints = "[B]reakpoints",
    scopes = "[S]copes",
    exceptions = "[E]xceptions",
    watches = "[W]atches",
    threads = "[T]hreads",
    repl = "[R]EPL",
    console = "[C]onsole",
  },
}
```

![Capture d’écran du 2025-04-12 00-20-49](https://github.com/user-attachments/assets/e71aaec2-7269-4b78-8733-a10f643fec96)

Or even setting some icons using NerdFonts:

![image](https://github.com/user-attachments/assets/eb024969-081b-4d15-acde-085ac96b1a5b)

![Capture d’écran du 2025-04-12 00-47-02](https://github.com/user-attachments/assets/8fd25309-c848-4a43-98ca-7d87356a8802)

![image](https://github.com/user-attachments/assets/9e7b22cc-6cda-4486-8554-e32f8f7cad70)

(Note: will conflict with #40, one will have to be rebased on the first merged)
