### PR TITLE
feat(winbar): add configurable control buttons

### DIFF
--- a/lua/dap-view/breakpoints/view.lua
+++ b/lua/dap-view/breakpoints/view.lua
@@ -11,7 +11,7 @@ local M = {}
 local api = vim.api
 
 M.show = function()
-    winbar.update_winbar("breakpoints")
+    winbar.update_section("breakpoints")
 
     if state.bufnr then
         -- Clear previous content

--- a/lua/dap-view/config.lua
+++ b/lua/dap-view/config.lua
@@ -5,6 +5,7 @@ local M = {}
 ---@field default_section SectionType
 ---@field show boolean
 ---@field headers WinbarHeaders Header label for each section.
+---@field controls ControlsConfig
 
 ---@class WinbarHeaders
 ---@field breakpoints string
@@ -14,6 +15,28 @@ local M = {}
 ---@field threads string
 ---@field repl string
 ---@field console string
+
+---@class ControlsConfig
+---@field enabled boolean
+---@field position 'left' | 'right'
+---@field buttons Button[] Buttons to show in the controls section.
+---@field custom_buttons table<CustomButton, ControlButton> Custom buttons to show in the controls section.
+---@field icons ControlsIcons Icons for each button.
+
+---@class ControlsIcons
+---@field pause string
+---@field play string
+---@field step_into string
+---@field step_over string
+---@field step_out string
+---@field step_back string
+---@field run_last string
+---@field terminate string
+---@field disconnect string
+
+---@class ControlButton
+---@field render fun(): string Render the button (highlight and icon).
+---@field action fun(clicks: integer, button: string, modifiers: string): nil Click handler. See `:help statusline`.
 
 ---@class TerminalConfig
 ---@field hide string[] Hide the terminal for listed adapters.
@@ -26,6 +49,10 @@ local M = {}
 ---@field terminal TerminalConfig
 
 ---@alias SectionType '"breakpoints"' | '"exceptions"' | '"watches"' | '"repl"' | '"threads"' | '"console"' | '"scopes"'
+
+---@alias CustomButton string
+---@alias DefaultButton '"play"' | '"step_into"' | '"step_over"' | '"step_out"' | '"step_back"' | '"run_last"' | '"terminate"' | '"disconnect"'
+---@alias Button CustomButton | DefaultButton
 
 ---@class Config
 ---@field winbar WinbarConfig
@@ -44,6 +71,32 @@ M.config = {
             threads = "Threads [T]",
             repl = "REPL [R]",
             console = "Console [C]",
+        },
+        controls = {
+            enabled = false,
+            position = "right",
+            buttons = {
+                "play",
+                "step_into",
+                "step_over",
+                "step_out",
+                "step_back",
+                "run_last",
+                "terminate",
+                "disconnect",
+            },
+            custom_buttons = {},
+            icons = {
+                pause = "",
+                play = "",
+                step_into = "",
+                step_over = "",
+                step_out = "",
+                step_back = "",
+                run_last = "",
+                terminate = "",
+                disconnect = "",
+            },
         },
     },
     windows = {

--- a/lua/dap-view/events.lua
+++ b/lua/dap-view/events.lua
@@ -9,6 +9,7 @@ local exceptions = require("dap-view.exceptions.view")
 local term = require("dap-view.term.init")
 local eval = require("dap-view.watches.eval")
 local setup = require("dap-view.setup")
+local winbar = require("dap-view.options.winbar")
 
 local SUBSCRIPTION_ID = "dap-view"
 
@@ -89,6 +90,8 @@ dap.listeners.after.event_stopped[SUBSCRIPTION_ID] = function(_, body)
             state.expression_results[i] = result
         end)
     end
+
+    winbar.redraw_controls()
 end
 
 dap.listeners.after.initialize[SUBSCRIPTION_ID] = function(session, _)
@@ -121,4 +124,19 @@ dap.listeners.after.event_terminated[SUBSCRIPTION_ID] = function()
     for k in ipairs(state.expression_results) do
         state.expression_results[k] = nil
     end
+
+    winbar.redraw_controls()
+end
+
+--- Refresh winbar on dap session state change events not having a dedicated event handler
+local events = {
+    "continue",
+    "disconnect",
+    "event_exited",
+    "restart",
+    "threads",
+}
+
+for _, event in ipairs(events) do
+    dap.listeners.after[event][SUBSCRIPTION_ID] = winbar.redraw_controls
 end

--- a/lua/dap-view/exceptions/view.lua
+++ b/lua/dap-view/exceptions/view.lua
@@ -10,7 +10,7 @@ local M = {}
 local api = vim.api
 
 M.show = function()
-    winbar.update_winbar("exceptions")
+    winbar.update_section("exceptions")
 
     if state.bufnr then
         -- Clear previous content

--- a/lua/dap-view/globals.lua
+++ b/lua/dap-view/globals.lua
@@ -1,4 +1,5 @@
 return {
     MAIN_BUF_NAME = "dap-view://main",
     NAMESPACE = vim.api.nvim_create_namespace("dap-view"),
+    HL_PREFIX = "NvimDapView",
 }

--- a/lua/dap-view/highlight.lua
+++ b/lua/dap-view/highlight.lua
@@ -1,9 +1,10 @@
 local api = vim.api
+local prefix = require("dap-view.globals").HL_PREFIX
 
 ---@param name string
 ---@param link string
 local hl_create = function(name, link)
-    api.nvim_set_hl(0, "NvimDapView" .. name, { link = link })
+    api.nvim_set_hl(0, prefix .. name, { link = link })
 end
 
 local define_base_links = function()
@@ -17,6 +18,20 @@ local define_base_links = function()
     hl_create("Separator", "Comment")
     hl_create("Thread", "@namespace")
     hl_create("ThreadStopped", "@conditional")
+
+    hl_create("Tab", "TabLine")
+    hl_create("TabSelected", "TabLineSel")
+
+    hl_create("ControlNC", "Comment")
+    hl_create("ControlPlay", "@keyword")
+    hl_create("ControlPause", "@boolean")
+    hl_create("ControlStepInto", "@function")
+    hl_create("ControlStepOut", "@function")
+    hl_create("ControlStepOver", "@function")
+    hl_create("ControlStepBack", "@function")
+    hl_create("ControlRunLast", "@keyword")
+    hl_create("ControlTerminate", "DapBreakpoint")
+    hl_create("ControlDisconnect", "DapBreakpoint")
 end
 
 define_base_links()

--- a/lua/dap-view/options/controls.lua
+++ b/lua/dap-view/options/controls.lua
@@ -1,0 +1,123 @@
+local statusline = require("dap-view.util.statusline")
+local setup = require("dap-view.setup")
+local dap = require("dap")
+local module = ...
+
+local M = {}
+
+---@type table<DefaultButton, ControlButton>
+local buttons = {
+    play = {
+        render = function()
+            local session = dap.session()
+            if not session or session.stopped_thread_id then
+                return statusline.hl(setup.config.winbar.controls.icons.play, "ControlPlay")
+            else
+                return statusline.hl(setup.config.winbar.controls.icons.pause, "ControlPause")
+            end
+        end,
+        action = function()
+            local session = dap.session()
+            if not session or session.stopped_thread_id then
+                dap.continue()
+            else
+                dap.pause()
+            end
+        end,
+    },
+    step_into = {
+        render = function()
+            local session = dap.session()
+            local active = session and session.stopped_thread_id
+            local hl = active and "ControlStepInto" or "ControlNC"
+            return statusline.hl(setup.config.winbar.controls.icons.step_into, hl)
+        end,
+        action = function()
+            dap.step_into()
+        end,
+    },
+    step_over = {
+        render = function()
+            local session = dap.session()
+            local active = session and session.stopped_thread_id
+            local hl = active and "ControlStepOver" or "ControlNC"
+            return statusline.hl(setup.config.winbar.controls.icons.step_over, hl)
+        end,
+        action = function()
+            dap.step_over()
+        end,
+    },
+    step_out = {
+        render = function()
+            local session = dap.session()
+            local active = session and session.stopped_thread_id
+            local hl = active and "ControlStepOut" or "ControlNC"
+            return statusline.hl(setup.config.winbar.controls.icons.step_out, hl)
+        end,
+        action = function()
+            dap.step_out()
+        end,
+    },
+    step_back = {
+        render = function()
+            local session = dap.session()
+            local active = session and session.stopped_thread_id
+            local hl = active and "ControlStepBack" or "ControlNC"
+            return statusline.hl(setup.config.winbar.controls.icons.step_back, hl)
+        end,
+        action = function()
+            dap.step_back()
+        end,
+    },
+    run_last = {
+        render = function()
+            return statusline.hl(setup.config.winbar.controls.icons.run_last, "ControlRunLast")
+        end,
+        action = function()
+            dap.run_last()
+        end,
+    },
+    terminate = {
+        render = function()
+            local hl = dap.session() and "ControlTerminate" or "ControlNC"
+            return statusline.hl(setup.config.winbar.controls.icons.terminate, hl)
+        end,
+        action = function()
+            dap.terminate()
+        end,
+    },
+    disconnect = {
+        render = function()
+            local hl = dap.session() and "ControlDisconnect" or "ControlNC"
+            return statusline.hl(setup.config.winbar.controls.icons.disconnect, hl)
+        end,
+        action = function()
+            dap.disconnect()
+        end,
+    },
+}
+
+---@param idx integer
+---@param clicks integer
+---@param button '"l"' | '"r"' | '"m"'
+---@param modifiers string
+M.on_click = function(idx, clicks, button, modifiers)
+    local config = setup.config.winbar.controls
+    local key = config.buttons[idx]
+    local control = config.custom_buttons[key] or buttons[key]
+    control.action(clicks, button, modifiers)
+end
+
+---@return string
+M.render = function()
+    local config = setup.config.winbar.controls
+    local bar = ""
+    for idx, key in ipairs(config.buttons) do
+        local control = config.custom_buttons[key] or buttons[key]
+        local icon = " " .. control.render() .. " "
+        bar = bar .. statusline.clickable(icon, module, "on_click", idx)
+    end
+    return bar
+end
+
+return M

--- a/lua/dap-view/scopes/view.lua
+++ b/lua/dap-view/scopes/view.lua
@@ -23,7 +23,7 @@ local new_widget = function()
 end
 
 M.show = function()
-    winbar.update_winbar("scopes")
+    winbar.update_section("scopes")
 
     if views.cleanup_view(not dap.session(), "No active session") then
         return

--- a/lua/dap-view/setup/validate/winbar.lua
+++ b/lua/dap-view/setup/validate/winbar.lua
@@ -9,6 +9,7 @@ function M.validate(config)
         sections = { config.sections, "table" },
         default_section = { config.default_section, "string" },
         headers = { config.headers, "table" },
+        controls = { config.controls, "table" },
     }, config)
 
     validate("winbar.headers", {
@@ -20,6 +21,27 @@ function M.validate(config)
         repl = { config.headers.repl, "string" },
         console = { config.headers.console, "string" },
     }, config.headers)
+
+    validate("winbar.controls", {
+        enabled = { config.controls.enabled, "boolean" },
+        position = { config.controls.position, "string" },
+        buttons = { config.controls.buttons, "table" },
+        icons = { config.controls.icons, "table" },
+        custom_buttons = { config.controls.custom_buttons, "table" },
+    }, config.controls)
+
+    local icons = config.controls.icons
+    validate("winbar.controls.icons", {
+        pause = { icons.pause, "string" },
+        play = { icons.play, "string" },
+        step_into = { icons.step_into, "string" },
+        step_over = { icons.step_over, "string" },
+        step_out = { icons.step_out, "string" },
+        step_back = { icons.step_back, "string" },
+        disconnect = { icons.disconnect, "string" },
+        terminate = { icons.terminate, "string" },
+        run_last = { icons.run_last, "string" },
+    }, icons)
 
     local sections = config.sections
     local default = config.default_section

--- a/lua/dap-view/threads/view.lua
+++ b/lua/dap-view/threads/view.lua
@@ -10,7 +10,7 @@ local M = {}
 local api = vim.api
 
 M.show = function()
-    winbar.update_winbar("threads")
+    winbar.update_section("threads")
 
     if state.bufnr then
         -- Clear previous content

--- a/lua/dap-view/util/statusline.lua
+++ b/lua/dap-view/util/statusline.lua
@@ -1,0 +1,18 @@
+local M = {}
+local prefix = require("dap-view.globals").HL_PREFIX
+
+---@param text string
+---@param group string
+M.hl = function(text, group)
+    return "%#" .. prefix .. group .. "#" .. text .. "%*"
+end
+
+---@param text string
+---@param module string
+---@param handler string
+---@param idx integer
+M.clickable = function(text, module, handler, idx)
+    return "%" .. idx .. "@v:lua.require'" .. module .. "'." .. handler .. "@" .. text .. "%T"
+end
+
+return M

--- a/lua/dap-view/watches/view.lua
+++ b/lua/dap-view/watches/view.lua
@@ -9,7 +9,7 @@ local M = {}
 local api = vim.api
 
 M.show = function()
-    winbar.update_winbar("watches")
+    winbar.update_section("watches")
 
     if state.bufnr then
         -- Clear previous content


### PR DESCRIPTION
Hi 👋🏼 

This PR adds an opt-in control bar widget.
By default, it is disabled, as this is a mouse-only widget, and it can be enabled with `winbar.controls.enabled=true`.

The buttons are dynamic, they are only actives when it's relevant (active debug session or not, session paused on a breakpoint or not...)  and they are greyed out when it's not.

It can be positioned at the left or the right (default) of the tabs with `winbar.controls.position="left"|"right"`. Positioned to the right, the widget is right aligned, and positioned to the left, the tabs are then right aligned.

**`winbar.controls.position="right"` (default)**

![image](https://github.com/user-attachments/assets/55982377-4d6d-42c3-8453-240a1395794b)

**`winbar.controls.position="left"`**

![image](https://github.com/user-attachments/assets/70df1f6a-89c7-4711-830f-b36c9c58b6cc)

Each icon can be changed with the `winbar.controls.icons` settings. It defaults to the `codicons` dedicated `debug` glyphs for each.

You can choose to display the buttons you want and their order with the `winbar.controls.buttons` table, default is `{"play", "step_into", "step_over", "step_out", "step_back", "run_last", "terminate", "disconnect"}`.

Each color can also be customized using the dedicated highlights

`terminate` and `disconnect` button can be hybrid with respectively `winbar.controls.terminate_run_last` and `winbar.controls.disconnect_run_last` (both default to `false`). When enabled, instead of being deactivated when no debug session is running, they are transformed into a `run_last` button, allowing to get rid of the `run_last` button if you want (some may still want it as it allows restarting a debug session when running).

As an example, here's my current setup:
```lua
winbar = {
	controls = {
		enabled = true,
        position = "left",
        buttons = {
            "play",
            "step_into",
            "step_over",
            "step_out",
            "terminate",
            "disconnect",
        },
        icons = {
            play = "",
            terminate = "",
        },
        terminate_run_last = true,
},
```
![image](https://github.com/user-attachments/assets/5e19949c-a861-4b95-ae94-0049c03c965d)
![image](https://github.com/user-attachments/assets/667a60a5-0a0c-4e9e-9767-1ecb83e27d20)

>[!NOTE]
> I did not added any screenshot to the README as I am not using thte same color scheme and the result would be inconsistent