### PR TITLE
feat: watches rewrite 

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ The console's default size (height) is resized to match your `nvim-dap-view` con
 You can also enable the control bar which exposes some clickable buttons by settings `winbar.controls.enable`.
 The control bar is fully customizable, checkout the options on default configuration section.
 
+![controls](https://github.com/user-attachments/assets/3d8d7102-7183-4acf-9759-6a7c7b354e9a)
+
 >[!NOTE]
 > Icons are using `Codicons` glyphs so it requires a Nerd Font
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,12 @@ return {
 The plugin provides 6 "views" that share the same window (so there's clutter)
 
 - Watches view
-    - Shows a list of (user defined) expressions, that are evaluated by the debug adapter
+    - Shows a list of user defined expressions, that are evaluated by the debug adapter
     - Add, edit and delete expressions from the watch list
-        - Including adding the variable under the cursor
+        - Add variable under the cursor using a command
+    - Copy the value of an expression
 
-![watches view](https://github.com/user-attachments/assets/c6838700-95ed-4b39-9ab5-e0ed0e753995)
+![watches view](https://github.com/user-attachments/assets/381a5c9c-7eea-4cdc-8358-a2afe9f247b2)
 
 - Exceptions view
     - Control when the debugger should stop, outside of breakpoints (e.g.,
@@ -206,10 +207,11 @@ in the `'winbar'` (e.g., `B` for the breakpoints view).
 
 The breakpoints view, the exceptions view and the scopes view only have 1
 mapping: `<CR>`. It jumps to a breakpoint, toggles an exception filter, and
-expands a variable, respectively. The watches view comes with 3 mappings:
+expands a variable, respectively. The watches view comes with 4 mappings:
 
 - `i` to insert a new expression
 - `e` to edit an expression
+- `c` to copy an expression (can't copy inner variables for now)
 - `d` to delete an expression
 
 Though, the preferred way of adding a new expression is using the

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@
             - [Jumping](#jumping)
             - [Expanding Variables](#expanding-variables)
         - [Highlight Groups](#highlight-groups)
-        - [Filetypes and autocommands](#filetypes-and-autocommands)
-        - [Custom buttons](#custom-buttons)
+        - [Filetypes and Autocommands](#filetypes-and-autocommands)
+        - [Custom Buttons](#custom-buttons)
     - [Roadmap](#roadmap)
     - [Known Issues](#known-issues)
     - [Acknowledgements](#acknowledgements)
@@ -324,7 +324,7 @@ return {
 
 ### Highlight Groups
 
-`nvim-dap-view` defines 22 highlight groups linked to (somewhat) reasonable defaults, but they may look odd with your colorscheme. If the links aren't defined, no highlighting will be applied. To fix that, you have to manually define the highlight groups (see `:h nvim_set_hl()`). Consider contributing to your colorscheme by sending a PR to add support to `nvim-dap-view`!
+`nvim-dap-view` defines 28 highlight groups linked to (somewhat) reasonable defaults, but they may look odd with your colorscheme. If the links aren't defined, no highlighting will be applied. To fix that, you have to manually define the highlight groups (see `:h nvim_set_hl()`). Consider contributing to your colorscheme by sending a PR to add support to `nvim-dap-view`!
 
 <details>
     <summary>Highlight groups</summary>
@@ -332,30 +332,35 @@ return {
 | Highlight Group                      | Default link                |
 |--------------------------------------|-----------------------------|
 | `NvimDapViewMissingData`             | `DapBreakpoint`             |
-| `NvimDapViewWatchText`               | `Comment`                   |
-| `NvimDapViewWatchTextChanged`        | `DiagnosticVirtualTextWarn` |
 | `NvimDapViewExceptionFilterEnabled`  | `DiagnosticOk`              |
 | `NvimDapViewExceptionFilterDisabled` | `DiagnosticError`           |
 | `NvimDapViewFileName`                | `qfFileName`                |
 | `NvimDapViewLineNumber`              | `qfLineNr`                  |
 | `NvimDapViewSeparator`               | `Comment`                   |
-| `NvimDapViewThread`                  | `@namespace`                |
-| `NvimDapViewThreadStopped`           | `@conditional`              |
+| `NvimDapViewThread`                  | `Tag`                       |
+| `NvimDapViewThreadStopped`           | `Conditional`               |
 | `NvimDapViewTab`                     | `TabLine`                   |
 | `NvimDapViewTabSelected`             | `TabLineSel`                |
 | `NvimDapViewControlNC`               | `Comment`                   |
-| `NvimDapViewControlPlay`             | `@keyword`                  |
-| `NvimDapViewControlPause`            | `@boolean`                  |
-| `NvimDapViewControlStepInto`         | `@function`                 |
-| `NvimDapViewControlStepOut`          | `@function`                 |
-| `NvimDapViewControlStepOver`         | `@function`                 |
-| `NvimDapViewControlStepBack`         | `@function`                 |
-| `NvimDapViewControlRunLast`          | `@keyword`                  |
+| `NvimDapViewControlPlay`             | `Keyword`                   |
+| `NvimDapViewControlPause`            | `Boolean`                   |
+| `NvimDapViewControlStepInto`         | `Function`                  |
+| `NvimDapViewControlStepOut`          | `Function`                  |
+| `NvimDapViewControlStepOver`         | `Function`                  |
+| `NvimDapViewControlStepBack`         | `Function`                  |
+| `NvimDapViewControlRunLast`          | `Keyword`                   |
 | `NvimDapViewControlTerminate`        | `DapBreakpoint`             |
 | `NvimDapViewControlDisconnect`       | `DapBreakpoint`             |
+| `NvimDapViewWatchExpr`               | `Identifier`                |
+| `NvimDapViewWatchError`              | `DiagnosticError`           |
+| `NvimDapViewWatchUpdated`            | `DiagnosticVirtualTextWarn` |
+| `NvimDapViewBoolean`                 | `Boolean`                   |
+| `NvimDapViewString`                  | `String`                    |
+| `NvimDapViewNumber`                  | `Number`                    |
+| `NvimDapViewFloat`                   | `Float`                     |
+| `NvimDapViewFunction`                | `Function`                  |
 
 <details>
-
 
 ### Filetypes and Autocommands
 
@@ -386,9 +391,9 @@ vim.api.nvim_create_autocmd({ "FileType" }, {
 
 </details>
 
-### Custom buttons
+### Custom Buttons
 
-`nvim-dap-view` provides some default buttons for the control bar, but you can also add your own. To do that, in the `controls` table you can use the `custom_buttons` table to declare your new button and then add it at the position you want in the `buttons` list. 
+`nvim-dap-view` provides some default buttons for the control bar, but you can also add your own. To do that, in the `controls` table you can use the `custom_buttons` table to declare your new button and then add it at the position you want in the `buttons` list.
 
 A custom button has 2 methods:
 
@@ -404,42 +409,50 @@ See the `@ N` section in `:help statusline` for the complete specifications of a
     <summary>Example custom buttons</summary>
 
 An example adding 2 buttons:
+
 - `fun`: the most basic button possible, just prints "🎊" when clicked
 - `term_restart`: an hybrid button that acts as a stop/restart button. If the stop button is triggered by anything else than a single left click (middle click, right click, double click or click with a modifier), it will disconnect the session instead.
 
 ```lua
-winbar = {
-  controls = {
-    enabled = true,
-    buttons = {"play", "step_into", "step_over", "step_out", "term_restart", "fun" },
-    custom_buttons = {
-      fun = {
-        render = function() return "🎉" end,
-        action = function() vim.print("🎊") end,
-      },
-      -- Stop/Restart button
-      -- Double click, middle click or click with a modifier disconnect instead of stop
-      term_restart = {
-        render = function()
-          local session = require("dap").session()
-          local group = session and "ControlTerminate" or "ControlRunLast"
-          local icon = session and "" or ""
-          return "%#NvimDapView" .. group .. "#" .. icon .. "%*"
-        end,
-        action = function(clicks, button, modifiers)
-          local dap = require("dap")
-          local alt = clicks > 1 or button ~= "l" or modifiers:gsub(" ", "") ~= ""
-          if not dap.session() then
-            dap.run_last()
-          elseif alt then
-            dap.disconnect()
-          else
-            dap.terminate()
-          end
-        end,
-      },
+-- No need to include the "return" statement
+return {
+    winbar = {
+        controls = {
+            enabled = true,
+            buttons = { "play", "step_into", "step_over", "step_out", "term_restart", "fun" },
+            custom_buttons = {
+                fun = {
+                    render = function()
+                        return "🎉"
+                    end,
+                    action = function()
+                        vim.print("🎊")
+                    end,
+                },
+                -- Stop/Restart button
+                -- Double click, middle click or click with a modifier disconnect instead of stop
+                term_restart = {
+                    render = function()
+                        local session = require("dap").session()
+                        local group = session and "ControlTerminate" or "ControlRunLast"
+                        local icon = session and "" or ""
+                        return "%#NvimDapView" .. group .. "#" .. icon .. "%*"
+                    end,
+                    action = function(clicks, button, modifiers)
+                        local dap = require("dap")
+                        local alt = clicks > 1 or button ~= "l" or modifiers:gsub(" ", "") ~= ""
+                        if not dap.session() then
+                            dap.run_last()
+                        elseif alt then
+                            dap.disconnect()
+                        else
+                            dap.terminate()
+                        end
+                    end,
+                },
+            },
+        },
     },
-  },
 }
 ```
 

--- a/lua/dap-view/events.lua
+++ b/lua/dap-view/events.lua
@@ -78,17 +78,11 @@ dap.listeners.after.stackTrace[SUBSCRIPTION_ID] = function()
     end
 end
 
-dap.listeners.after.event_stopped[SUBSCRIPTION_ID] = function(_, body)
-    state.stopped_thread = body.threadId
-
+dap.listeners.after.event_stopped[SUBSCRIPTION_ID] = function()
     require("dap-view.threads").get_threads()
 
-    for i, expr in ipairs(state.watched_expressions) do
-        eval.eval_expr(expr, function(result)
-            local has_changed = state.expression_results[i] ~= result
-            state.updated_evaluations[i] = state.expression_results[i] and has_changed
-            state.expression_results[i] = result
-        end)
+    for expr, _ in pairs(state.watched_expressions) do
+        eval.eval_expr(expr)
     end
 
     winbar.redraw_controls()
@@ -118,11 +112,6 @@ dap.listeners.after.event_terminated[SUBSCRIPTION_ID] = function()
     -- Refresh threads view on exit to avoid showing outdated trace
     if state.current_section == "threads" then
         threads.show()
-    end
-
-    -- Clear evaluations so new sessions don't get highlighted as changed
-    for k in ipairs(state.expression_results) do
-        state.expression_results[k] = nil
     end
 
     winbar.redraw_controls()

--- a/lua/dap-view/highlight.lua
+++ b/lua/dap-view/highlight.lua
@@ -9,15 +9,14 @@ end
 
 local define_base_links = function()
     hl_create("MissingData", "DapBreakpoint")
-    hl_create("WatchText", "Comment")
-    hl_create("WatchTextChanged", "DiagnosticVirtualTextWarn")
-    hl_create("ExceptionFilterEnabled", "DiagnosticOk")
-    hl_create("ExceptionFilterDisabled", "DiagnosticError")
     hl_create("FileName", "qfFileName")
     hl_create("LineNumber", "qfLineNr")
     hl_create("Separator", "Comment")
     hl_create("Thread", "@namespace")
     hl_create("ThreadStopped", "@conditional")
+
+    hl_create("ExceptionFilterEnabled", "DiagnosticOk")
+    hl_create("ExceptionFilterDisabled", "DiagnosticError")
 
     hl_create("Tab", "TabLine")
     hl_create("TabSelected", "TabLineSel")
@@ -32,6 +31,15 @@ local define_base_links = function()
     hl_create("ControlRunLast", "@keyword")
     hl_create("ControlTerminate", "DapBreakpoint")
     hl_create("ControlDisconnect", "DapBreakpoint")
+    hl_create("WatchExpr", "Identifier")
+    hl_create("WatchError", "DiagnosticError")
+    hl_create("WatchUpdated", "DiagnosticVirtualTextWarn")
+
+    hl_create("Boolean", "Boolean")
+    hl_create("String", "String")
+    hl_create("Number", "Number")
+    hl_create("Float", "Float")
+    hl_create("Function", "Function")
 end
 
 define_base_links()

--- a/lua/dap-view/highlight.lua
+++ b/lua/dap-view/highlight.lua
@@ -1,10 +1,11 @@
+local globals = require("dap-view.globals")
+
 local api = vim.api
-local prefix = require("dap-view.globals").HL_PREFIX
 
 ---@param name string
 ---@param link string
 local hl_create = function(name, link)
-    api.nvim_set_hl(0, prefix .. name, { link = link })
+    api.nvim_set_hl(0, globals.HL_PREFIX .. name, { link = link })
 end
 
 local define_base_links = function()
@@ -12,8 +13,8 @@ local define_base_links = function()
     hl_create("FileName", "qfFileName")
     hl_create("LineNumber", "qfLineNr")
     hl_create("Separator", "Comment")
-    hl_create("Thread", "@namespace")
-    hl_create("ThreadStopped", "@conditional")
+    hl_create("Thread", "Tag")
+    hl_create("ThreadStopped", "Conditional")
 
     hl_create("ExceptionFilterEnabled", "DiagnosticOk")
     hl_create("ExceptionFilterDisabled", "DiagnosticError")
@@ -22,15 +23,16 @@ local define_base_links = function()
     hl_create("TabSelected", "TabLineSel")
 
     hl_create("ControlNC", "Comment")
-    hl_create("ControlPlay", "@keyword")
-    hl_create("ControlPause", "@boolean")
-    hl_create("ControlStepInto", "@function")
-    hl_create("ControlStepOut", "@function")
-    hl_create("ControlStepOver", "@function")
-    hl_create("ControlStepBack", "@function")
-    hl_create("ControlRunLast", "@keyword")
+    hl_create("ControlPlay", "Keyword")
+    hl_create("ControlPause", "Boolean")
+    hl_create("ControlStepInto", "Function")
+    hl_create("ControlStepOut", "Function")
+    hl_create("ControlStepOver", "Function")
+    hl_create("ControlStepBack", "Function")
+    hl_create("ControlRunLast", "Keyword")
     hl_create("ControlTerminate", "DapBreakpoint")
     hl_create("ControlDisconnect", "DapBreakpoint")
+
     hl_create("WatchExpr", "Identifier")
     hl_create("WatchError", "DiagnosticError")
     hl_create("WatchUpdated", "DiagnosticVirtualTextWarn")

--- a/lua/dap-view/options/controls.lua
+++ b/lua/dap-view/options/controls.lua
@@ -1,6 +1,7 @@
+local dap = require("dap")
+
 local statusline = require("dap-view.util.statusline")
 local setup = require("dap-view.setup")
-local dap = require("dap")
 local module = ...
 
 local M = {}

--- a/lua/dap-view/state.lua
+++ b/lua/dap-view/state.lua
@@ -10,25 +10,24 @@
 ---@field winnr? integer
 ---@field term_bufnr? integer
 ---@field term_winnr? integer
----@field stopped_thread? integer
 ---@field last_active_adapter? string
 ---@field current_section? SectionType
 ---@field exceptions_options ExceptionsOption[]
 ---@field threads ThreadWithErr[]
 ---@field threads_err? string
 ---@field frames_by_line {[number]: dap.StackFrame[]}
+---@field expressions_by_line {[integer]: string}
+---@field variables_by_reference table<integer, {variable: dap.Variable, updated: boolean}[] | string>
 ---@field subtle_frames boolean
----@field watched_expressions string[]
----@field expression_results string[]
----@field updated_evaluations boolean[]
+---@field watched_expressions table<string,{response?: (dap.EvaluateResponse | string), updated?: boolean}>
 local M = {
     exceptions_options = {},
     threads = {},
     frames_by_line = {},
+    expressions_by_line = {},
+    variables_by_reference = {},
     subtle_frames = false,
     watched_expressions = {},
-    expression_results = {},
-    updated_evaluations = {},
 }
 
 return M

--- a/lua/dap-view/threads/view.lua
+++ b/lua/dap-view/threads/view.lua
@@ -16,7 +16,9 @@ M.show = function()
         -- Clear previous content
         api.nvim_buf_set_lines(state.bufnr, 0, -1, true, {})
 
-        if views.cleanup_view(not dap.session(), "No active session") then
+        local session = dap.session()
+        -- Redundant check to appease the type checker
+        if views.cleanup_view(session == nil, "No active session") or session == nil then
             return
         end
 
@@ -35,7 +37,7 @@ M.show = function()
         local line = 0
         for _, thread in pairs(state.threads) do
             api.nvim_buf_set_lines(state.bufnr, line, -1, false, { thread.name })
-            local is_stopped_thread = state.stopped_thread == thread.id
+            local is_stopped_thread = session.stopped_thread_id == thread.id
             hl.hl_range(is_stopped_thread and "ThreadStopped" or "Thread", { line, 0 }, { line, -1 })
 
             local valid_frames = vim.iter(thread.frames or {})

--- a/lua/dap-view/util/statusline.lua
+++ b/lua/dap-view/util/statusline.lua
@@ -1,5 +1,6 @@
-local M = {}
 local global = require("dap-view.globals")
+
+local M = {}
 
 ---@param text string
 ---@param group string

--- a/lua/dap-view/util/statusline.lua
+++ b/lua/dap-view/util/statusline.lua
@@ -1,10 +1,10 @@
 local M = {}
-local prefix = require("dap-view.globals").HL_PREFIX
+local global = require("dap-view.globals")
 
 ---@param text string
 ---@param group string
 M.hl = function(text, group)
-    return "%#" .. prefix .. group .. "#" .. text .. "%*"
+    return "%#" .. global.HL_PREFIX .. group .. "#" .. text .. "%*"
 end
 
 ---@param text string

--- a/lua/dap-view/views/keymaps.lua
+++ b/lua/dap-view/views/keymaps.lua
@@ -30,9 +30,9 @@ M.set_keymaps = function()
 
     vim.keymap.set("n", "d", function()
         if state.current_section == "watches" then
-            local line = vim.api.nvim_win_get_cursor(state.winnr)[1]
+            local cursor_line = vim.api.nvim_win_get_cursor(state.winnr)[1]
 
-            watches_actions.remove_watch_expr(line)
+            watches_actions.remove_watch_expr(cursor_line)
 
             watches_view.show()
         end
@@ -40,18 +40,26 @@ M.set_keymaps = function()
 
     vim.keymap.set("n", "e", function()
         if state.current_section == "watches" then
-            local line = vim.api.nvim_win_get_cursor(state.winnr)[1]
+            local cursor_line = vim.api.nvim_win_get_cursor(state.winnr)[1]
 
             vim.ui.input(
-                { prompt = "Expression: ", default = state.watched_expressions[line] },
+                { prompt = "Expression: ", default = state.expressions_by_line[cursor_line] },
                 function(input)
                     if input then
-                        watches_actions.edit_watch_expr(input, line)
+                        watches_actions.edit_watch_expr(input, cursor_line)
                     end
                 end
             )
         end
     end, { buffer = state.bufnr })
+
+    vim.keymap.set("n", "c", function()
+        if state.current_section == "watches" then
+            local cursor_line = vim.api.nvim_win_get_cursor(state.winnr)[1]
+
+            watches_actions.copy_watch_expr(cursor_line)
+        end
+    end, { buffer = state.bufnr, nowait = true })
 
     vim.keymap.set("n", "t", function()
         if state.current_section == "threads" then
@@ -59,7 +67,7 @@ M.set_keymaps = function()
 
             threads_view.show()
         end
-    end, { buffer = state.bufnr })
+    end, { buffer = state.bufnr, nowait = true })
 end
 
 return M

--- a/lua/dap-view/views/options.lua
+++ b/lua/dap-view/views/options.lua
@@ -13,6 +13,7 @@ M.set_options = function()
     win.cursorline = true
     win.statuscolumn = ""
     win.foldcolumn = "0"
+    win.foldmethod = "indent"
 
     local buf = vim.bo[state.bufnr]
     buf.buftype = "nofile"

--- a/lua/dap-view/watches/eval.lua
+++ b/lua/dap-view/watches/eval.lua
@@ -1,8 +1,37 @@
+local state = require("dap-view.state")
+
 local M = {}
 
+---@param variables_reference number
+---@param frame_id? number
+local eval_variables = function(variables_reference, frame_id)
+    local session = assert(require("dap").session(), "has active session")
+
+    local err, result = session:request(
+        "variables",
+        { variablesReference = variables_reference, context = "watch", frameId = frame_id }
+    )
+
+    local response = err and tostring(err) or result and result.variables
+
+    --[[@type {variable?: dap.Variable, updated?: boolean}[] | string]]
+    local variables = type(response) == "string" and response or {}
+
+    local original = state.variables_by_reference[variables_reference]
+
+    -- Lua's type checking is a lackluster
+    if type(variables) ~= "string" and type(response) ~= "string" then
+        for k, var in pairs(response or {}) do
+            local updated = type(original) == "table" and original[k].variable.value ~= var.value or false
+            table.insert(variables, { variable = var, updated = updated })
+        end
+    end
+
+    state.variables_by_reference[variables_reference] = variables
+end
+
 ---@param expr string
----@param callback fun(result: string): nil
-M.eval_expr = function(expr, callback)
+M.eval_expr = function(expr)
     local session = assert(require("dap").session(), "has active session")
 
     coroutine.wrap(function()
@@ -11,35 +40,37 @@ M.eval_expr = function(expr, callback)
         local err, result =
             session:request("evaluate", { expression = expr, context = "watch", frameId = frame_id })
 
-        local expr_result = result and result.result or err and tostring(err):gsub("%s+", " ") or ""
+        local original = state.watched_expressions[expr] and state.watched_expressions[expr].response.result
+        local response = err and tostring(err) or result
+        local updated = original and response and original ~= response.result
+        state.watched_expressions[expr] = { response = response, updated = updated }
 
-        -- TODO currently, we only check for variables reference for the top level expression
-        -- It would be nice to expose functionality to let the user control the depth
-        -- This could be a config parameter (eg, base depth) but could also extend with an action (BFS)
         local variables_reference = result and result.variablesReference
         if variables_reference and variables_reference > 0 then
-            local enhanced_expr_result = { expr_result }
-
-            local var_ref_err, var_ref_result = session:request(
-                "variables",
-                { variablesReference = variables_reference, context = "watch", frameId = frame_id }
-            )
-
-            if var_ref_err then
-                table.insert(enhanced_expr_result, tostring(err))
-            elseif var_ref_result then
-                for _, k in pairs(var_ref_result.variables) do
-                    table.insert(enhanced_expr_result, "\t" .. k.name .. " = " .. k.value)
-                end
-            end
-
-            local final_result = table.concat(enhanced_expr_result, "\n")
-
-            callback(final_result)
-        else
-            callback(expr_result)
+            eval_variables(variables_reference, frame_id)
         end
     end)()
+end
+
+---@param expr string
+M.copy_expr = function(expr)
+    local session = assert(require("dap").session(), "has active session")
+
+    if session.capabilities.supportsClipboardContext then
+        coroutine.wrap(function()
+            local frame_id = session.current_frame and session.current_frame.id
+
+            local err, result =
+                session:request("evaluate", { expression = expr, context = "clipboard", frameId = frame_id })
+
+            if err == nil and result then
+                -- TODO uses system clipboard, could be a parameter instead
+                vim.fn.setreg("+", result.result)
+            end
+        end)()
+    else
+        vim.notify("Adapter doesn't support clipboard evaluation")
+    end
 end
 
 return M

--- a/lua/dap-view/watches/view.lua
+++ b/lua/dap-view/watches/view.lua
@@ -1,12 +1,63 @@
 local state = require("dap-view.state")
 local winbar = require("dap-view.options.winbar")
-local globals = require("dap-view.globals")
 local views = require("dap-view.views")
-local util_string = require("dap-view.util.string")
+local hl = require("dap-view.util.hl")
 
 local M = {}
 
 local api = vim.api
+
+-- TODO There's also 'list' and 'dict'
+local types_to_hl_group = {
+    boolean = "Boolean",
+    str = "String",
+    string = "String",
+    int = "Number",
+    long = "Number",
+    number = "Number",
+    double = "Float",
+    float = "Float",
+    ["function"] = "Function",
+}
+
+---@param line integer
+---@param response string|dap.EvaluateResponse
+---@return integer
+local show_variables = function(line, response)
+    if type(response) ~= "string" then
+        local variables = state.variables_by_reference[response.variablesReference]
+        if type(variables) == "string" then
+            local var_content = "\t" .. variables
+            api.nvim_buf_set_lines(state.bufnr, line, line + 1, false, { var_content })
+
+            line = line + 1
+        else
+            for _, var in ipairs(variables or {}) do
+                local variable = var.variable
+                local value = #variable.value > 0 and variable.value
+                    or variable.variablesReference > 0 and "..."
+                    or ""
+                local content = "\t" .. variable.name .. " = " .. value
+
+                -- Can't have linebreaks with nvim_buf_set_lines
+                local trimmed_content = content:gsub("%s+", " ")
+
+                api.nvim_buf_set_lines(state.bufnr, line, line + 1, false, { trimmed_content })
+
+                hl.hl_range("WatchExpr", { line, 1 }, { line, 1 + #variable.name })
+
+                local hl_group = var.updated and "WatchUpdated" or types_to_hl_group[variable.type:lower()]
+                if hl_group then
+                    local _hl_start = #variable.name + 4
+                    hl.hl_range(hl_group, { line, _hl_start }, { line, -1 })
+                end
+
+                line = line + 1
+            end
+        end
+    end
+    return line
+end
 
 M.show = function()
     winbar.update_section("watches")
@@ -15,36 +66,44 @@ M.show = function()
         -- Clear previous content
         api.nvim_buf_set_lines(state.bufnr, 0, -1, true, {})
 
-        if views.cleanup_view(#state.watched_expressions == 0, "No expressions") then
-            return
+        views.cleanup_view(#state.watched_expressions == 0, "No expressions")
+
+        -- Since variables aren't ordered, lines may change unexpectedly
+        -- To handle that, always clear the storage table
+        for k, _ in pairs(state.expressions_by_line) do
+            state.expressions_by_line[k] = nil
         end
 
-        api.nvim_buf_set_lines(
-            state.bufnr,
-            0,
-            #state.watched_expressions + 1,
-            false,
-            state.watched_expressions
-        )
+        local line = 0
+        for expr, eval in pairs(state.watched_expressions) do
+            local response = eval.response
 
-        for i = 1, #state.watched_expressions do
-            local hl_group = state.updated_evaluations[i] and "NvimDapViewWatchTextChanged"
-                or "NvimDapViewWatchText"
-            local expr_result = state.expression_results[i]
+            assert(response ~= nil, "Response exists")
 
-            if expr_result then
-                local split_lines = util_string.split_string_to_table(expr_result)
-                local virt_lines = vim.iter(split_lines)
-                    :map(function(r)
-                        return { { r, hl_group } }
-                    end)
-                    :totable()
+            local result = type(response) == "string" and response or response.result
 
-                api.nvim_buf_set_extmark(state.bufnr, globals.NAMESPACE, i - 1, 0, {
-                    virt_lines = virt_lines,
-                    virt_lines_overflow = "scroll",
-                })
+            local content = expr .. " = " .. result
+
+            -- Can't have linebreaks with nvim_buf_set_lines
+            local trimmed_content = content:gsub("%s+", " ")
+
+            api.nvim_buf_set_lines(state.bufnr, line, line + 1, false, { trimmed_content })
+
+            hl.hl_range("WatchExpr", { line, 0 }, { line, #expr })
+
+            local hl_group = type(response) == "string" and "WatchError"
+                or eval.updated and "WatchUpdated"
+                or response and types_to_hl_group[response.type:lower()]
+            if hl_group then
+                local hl_start = #expr + 3
+                hl.hl_range(hl_group, { line, hl_start }, { line, -1 })
             end
+
+            line = line + 1
+
+            state.expressions_by_line[line] = expr
+
+            line = show_variables(line, response)
         end
     end
 end


### PR DESCRIPTION
Related #33

## Preview

![image](https://github.com/user-attachments/assets/381a5c9c-7eea-4cdc-8358-a2afe9f247b2)

## Drawbacks

- UI inconsistencies with the scopes view. The scopes view has some advantages when it comes to folding. More specifically, `<CR>` can be used for both collapsing and expanding, which is something I currently have no idea how to do. Might figure this out, but I've been thinking about upstreaming this feature (if appropriate), so this wouldn't be an issue. Also, indent-based collapsing isn't as cool as the alternative.
- Some actions only apply to expressions themselves, and not their inner variables. That's the case for:
  - `copy` => Can't copy variables. That's no biggie, I guess, since now we can properly move around and copy them directly
  - ~variables aren't highlighted when their value change, only expressions. I think this would be somewhat annoying to implement, so leaving it out from this initial implementation~ Done

## Follow-up

New state is a huge improvement already. Gonna split the work in a follow-up containing the following features:
- [ ] Variable expansion
- [ ] Better folding / collapsing
- [ ] Copying variables
- [ ] `setVariables` request
- [ ] `setExpression` request