### PR TITLE
fix(README): typo in highlight groups closing details markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ return {
 | `NvimDapViewControlTerminate`        | `DapBreakpoint`             |
 | `NvimDapViewControlDisconnect`       | `DapBreakpoint`             |
 
-<details>
+</details>
 
 
 ### Filetypes and Autocommands


### PR DESCRIPTION
Oups, a typo broke the README 😅 