### PR TITLE
feat(watches): expand variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The plugin provides 6 "views" that share the same window (so there's clutter)
     - Shows a list of user defined expressions, that are evaluated by the debug adapter
     - Add, edit and delete expressions from the watch list
         - Add variable under the cursor using a command
+    - Expand and collapse expressions and variables
     - Set the value of an expression or variable (if supported by debug adapter)
     - Copy the value of an expression or variable
 
@@ -208,14 +209,13 @@ Start a regular debugging session. When desired, you can use `:DapViewOpen` to
 start the plugin. You can switch to a view (section) using the letter outlined
 in the `'winbar'` (e.g., `B` for the breakpoints view).
 
-The breakpoints view, the exceptions view and the scopes view only have 1
-mapping: `<CR>`. It jumps to a breakpoint, toggles an exception filter, and
-expands a variable, respectively. The watches view comes with 5 mappings:
+The breakpoints view and the exceptions view only have 1 mapping: `<CR>`. It jumps to a breakpoint and toggles an exception filter, respectively. The watches view comes with 6 mappings:
 
+- `<CR>` to expand or collapse a variable
 - `i` to insert a new expression
 - `e` to edit an expression
 - `c` to copy an expression or variable
-- `s` to change the value of an expression or variable
+- `s` to set (change) the value of an expression or variable
 - `d` to delete an expression
 
 Though, the preferred way of adding a new expression is using the
@@ -224,6 +224,11 @@ to the watch list. The threads view has 2 mappings:
 
 - `<CR>` jumps to a location in the call stack
 - `t` toggles subtle frames
+
+Similarly, the scopes view comes with 2 mappings:
+
+- `<CR>` to expand or collapse a variable
+- `o` to open a menu with further actions
 
 When you finish your session, you can use `:DapViewClose` to close the
 `nvim-dap-view` window.

--- a/lua/dap-view/events.lua
+++ b/lua/dap-view/events.lua
@@ -64,6 +64,11 @@ dap.listeners.after.scopes[SUBSCRIPTION_ID] = function()
     if state.current_section == "scopes" and state.bufnr then
         scopes.refresh()
     end
+
+    -- Avoid race conditions by not using `event_stopped`
+    for expr, _ in pairs(state.watched_expressions) do
+        eval.eval_expr(expr)
+    end
 end
 
 dap.listeners.after.variables[SUBSCRIPTION_ID] = function()
@@ -80,10 +85,6 @@ end
 
 dap.listeners.after.event_stopped[SUBSCRIPTION_ID] = function()
     require("dap-view.threads").get_threads()
-
-    for expr, _ in pairs(state.watched_expressions) do
-        eval.eval_expr(expr)
-    end
 
     winbar.redraw_controls()
 end

--- a/lua/dap-view/events.lua
+++ b/lua/dap-view/events.lua
@@ -53,12 +53,6 @@ dap.listeners.after.setBreakpoints[SUBSCRIPTION_ID] = function()
     end
 end
 
-dap.listeners.after.evaluate[SUBSCRIPTION_ID] = function()
-    if state.current_section == "watches" then
-        watches.show()
-    end
-end
-
 dap.listeners.after.scopes[SUBSCRIPTION_ID] = function()
     -- nvim-dap needs a buffer to operate
     if state.current_section == "scopes" and state.bufnr then

--- a/lua/dap-view/state.lua
+++ b/lua/dap-view/state.lua
@@ -5,6 +5,23 @@
 ---@class ThreadWithErr: dap.Thread
 ---@field err? string
 
+---@class ExpressionPack
+---@field response? dap.EvaluateResponse | string
+---@field children? VariablePack[] | string
+---@field expanded boolean
+---@field updated boolean
+
+---@class VariablePack
+---@field variable dap.Variable
+---@field updated boolean
+---@field reference number
+---@field expanded boolean
+---@field children string|VariablePack[]
+
+-- Necessary for some type assertions
+---@class VariablePackNested : VariablePack
+---@field children VariablePack[]
+
 ---@class State
 ---@field bufnr? integer
 ---@field winnr? integer
@@ -16,17 +33,15 @@
 ---@field exceptions_options ExceptionsOption[]
 ---@field threads ThreadWithErr[]
 ---@field threads_err? string
----@field frames_by_line {[number]: dap.StackFrame[]}
----@field expressions_by_line {[integer]: {name: string, response: dap.EvaluateResponse | string}}
----@field variables_by_reference table<integer, {variable: dap.Variable, updated: boolean}[] | string>
+---@field frames_by_line table<integer, dap.StackFrame[]>
+---@field expressions_by_line table<integer, {name: string, expression: ExpressionPack}>
 ---@field variables_by_line table<integer, {response: dap.Variable, reference: number}>
----@field watched_expressions table<string,{response?: dap.EvaluateResponse | string, updated?: boolean}>
+---@field watched_expressions table<string, ExpressionPack>
 local M = {
     exceptions_options = {},
     threads = {},
     frames_by_line = {},
     expressions_by_line = {},
-    variables_by_reference = {},
     variables_by_line = {},
     subtle_frames = false,
     watched_expressions = {},

--- a/lua/dap-view/tree/traversal.lua
+++ b/lua/dap-view/tree/traversal.lua
@@ -1,0 +1,37 @@
+local state = require("dap-view.state")
+
+local M = {}
+
+---@param children VariablePack[]
+---@param reference number
+---@return VariablePack?
+local function dfs(children, reference)
+    for _, v in pairs(children) do
+        if v.variable.variablesReference == reference then
+            return v
+        end
+        if v.children and type(v.children) ~= "string" then
+            ---@cast v VariablePackNested
+            local ref = dfs(v.children, reference)
+            if ref then
+                return ref
+            end
+        end
+    end
+end
+
+---@param reference number
+---@return VariablePack?
+M.find_node = function(reference)
+    for _, v in pairs(state.watched_expressions) do
+        local children = v.children
+        if children and type(children) ~= "string" then
+            local ref = dfs(children, reference)
+            if ref then
+                return ref
+            end
+        end
+    end
+end
+
+return M

--- a/lua/dap-view/views/keymaps.lua
+++ b/lua/dap-view/views/keymaps.lua
@@ -15,6 +15,9 @@ M.set_keymaps = function()
             require("dap-view.exceptions.actions").toggle_exception_filter()
         elseif state.current_section == "scopes" then
             require("dap.ui").trigger_actions({ mode = "first" })
+        elseif state.current_section == "watches" then
+            local cursor_line = vim.api.nvim_win_get_cursor(state.winnr)[1]
+            watches_actions.expand_or_collapse(cursor_line)
         end
     end, { buffer = state.bufnr })
 
@@ -73,8 +76,8 @@ M.set_keymaps = function()
 
             local get_default = function()
                 local expr = state.expressions_by_line[cursor_line]
-                if expr and type(expr.response) ~= "string" then
-                    return expr.response.result
+                if expr and expr.expression and type(expr.expression.response) ~= "string" then
+                    return expr.expression.response.result
                 end
 
                 local var = state.variables_by_line[cursor_line]

--- a/lua/dap-view/views/options.lua
+++ b/lua/dap-view/views/options.lua
@@ -4,7 +4,7 @@ local M = {}
 
 M.set_options = function()
     local win = vim.wo[state.winnr][0]
-    win.scrolloff = 0
+    win.scrolloff = 99
     win.wrap = false
     win.number = false
     win.relativenumber = false

--- a/lua/dap-view/watches/actions.lua
+++ b/lua/dap-view/watches/actions.lua
@@ -23,8 +23,6 @@ M.remove_watch_expr = function(line)
     local expr = state.expressions_by_line[line]
     if expr then
         state.watched_expressions[expr.name] = nil
-        -- Recurisvely cleanup
-        state.expressions_by_line[line] = nil
     else
         vim.notify("No expression under the under cursor")
     end

--- a/lua/dap-view/watches/actions.lua
+++ b/lua/dap-view/watches/actions.lua
@@ -3,6 +3,7 @@ local guard = require("dap-view.guard")
 local eval = require("dap-view.watches.eval")
 local set = require("dap-view.watches.set")
 local traversal = require("dap-view.tree.traversal")
+local watches_view = require("dap-view.watches.view")
 
 local M = {}
 
@@ -13,7 +14,9 @@ M.add_watch_expr = function(expr)
         return false
     end
 
-    eval.eval_expr(expr)
+    eval.eval_expr(expr, function()
+        watches_view.show()
+    end)
 
     return true
 end
@@ -106,7 +109,9 @@ M.edit_watch_expr = function(expr, line)
     -- The easiest way to edit is to delete and insert again
     M.remove_watch_expr(line)
 
-    eval.eval_expr(expr)
+    eval.eval_expr(expr, function()
+        watches_view.show()
+    end)
 end
 
 ---@param line number
@@ -123,7 +128,9 @@ M.expand_or_collapse = function(line)
         if e then
             e.expanded = not e.expanded
 
-            eval.eval_expr(expr.name)
+            eval.eval_expr(expr.name, function()
+                watches_view.show()
+            end)
         end
     else
         if var then

--- a/lua/dap-view/watches/actions.lua
+++ b/lua/dap-view/watches/actions.lua
@@ -2,6 +2,7 @@ local state = require("dap-view.state")
 local guard = require("dap-view.guard")
 local eval = require("dap-view.watches.eval")
 local set = require("dap-view.watches.set")
+local traversal = require("dap-view.tree.traversal")
 
 local M = {}
 
@@ -21,18 +22,9 @@ end
 M.remove_watch_expr = function(line)
     local expr = state.expressions_by_line[line]
     if expr then
-        local eval_result = state.watched_expressions[expr.name].response
-
         state.watched_expressions[expr.name] = nil
+        -- Recurisvely cleanup
         state.expressions_by_line[line] = nil
-
-        -- If the result is a string, it's the error
-        if type(eval_result) ~= "string" then
-            local ref = eval_result and eval_result.variablesReference
-            if ref then
-                state.variables_by_reference[ref] = nil
-            end
-        end
     else
         vim.notify("No expression under the under cursor")
     end
@@ -117,6 +109,42 @@ M.edit_watch_expr = function(expr, line)
     M.remove_watch_expr(line)
 
     eval.eval_expr(expr)
+end
+
+---@param line number
+M.expand_or_collapse = function(line)
+    if not guard.expect_session() then
+        return
+    end
+
+    local var = state.variables_by_line[line]
+
+    local expr = state.expressions_by_line[line]
+    if expr then
+        local e = state.watched_expressions[expr.name]
+        if e then
+            e.expanded = not e.expanded
+
+            eval.eval_expr(expr.name)
+        end
+    else
+        if var then
+            local reference = var.response.variablesReference
+            if reference > 0 then
+                local v = traversal.find_node(reference)
+                if v then
+                    v.expanded = not v.expanded
+                    eval.expand_var(reference, v.children, function(result)
+                        v.children = result
+                    end)
+                end
+            else
+                vim.notify("Nothing to expand")
+            end
+        else
+            vim.notify("No expression or variable under the under cursor")
+        end
+    end
 end
 
 return M

--- a/lua/dap-view/watches/eval.lua
+++ b/lua/dap-view/watches/eval.lua
@@ -22,7 +22,6 @@ M.eval_expr = function(expr_name)
         local response = err and tostring(err) or result
 
         if err and previous_expr then
-            -- Should destroy children recursively to not leak
             previous_expr.children = nil
         end
 
@@ -118,7 +117,6 @@ function M.expand_var(variables_reference, original, callback)
                             end
                         )
                         if err and previous then
-                            -- Should destroy children recursively to not leak
                             previous.children = nil
                             previous.expanded = false
                             previous.updated = false

--- a/lua/dap-view/watches/eval.lua
+++ b/lua/dap-view/watches/eval.lua
@@ -4,7 +4,8 @@ local state = require("dap-view.state")
 local M = {}
 
 ---@param expr_name string
-M.eval_expr = function(expr_name)
+---@param callback? fun(): nil
+M.eval_expr = function(expr_name, callback)
     local session = assert(require("dap").session(), "has active session")
 
     coroutine.wrap(function()
@@ -46,9 +47,17 @@ M.eval_expr = function(expr_name)
                 new_expr.children = children
 
                 state.watched_expressions[expr_name] = new_expr
+
+                if callback then
+                    callback()
+                end
             end)
         else
             state.watched_expressions[expr_name] = new_expr
+
+            if callback then
+                callback()
+            end
         end
     end)()
 end

--- a/lua/dap-view/watches/eval.lua
+++ b/lua/dap-view/watches/eval.lua
@@ -109,7 +109,12 @@ function M.expand_var(variables_reference, original, callback)
                         previous = vim.iter(original or {}):find(
                             ---@param v VariablePack
                             function(v)
-                                return var.evaluateName == v.variable.evaluateName
+                                if v.variable.evaluateName then
+                                    return v.variable.evaluateName == var.evaluateName
+                                end
+                                if v.variable.variablesReference > 0 then
+                                    return v.variable.variablesReference == var.variablesReference
+                                end
                             end
                         )
                         if err and previous then

--- a/lua/dap-view/watches/view.lua
+++ b/lua/dap-view/watches/view.lua
@@ -41,7 +41,8 @@ local function show_variables(children, reference, line, depth)
 
         hl.hl_range("WatchExpr", { line, depth }, { line, depth + #variable.name })
 
-        local hl_group = var.updated and "WatchUpdated" or types_to_hl_group[variable.type:lower()]
+        local hl_group = var.updated and "WatchUpdated"
+            or variable.type and types_to_hl_group[variable.type:lower()]
         if hl_group then
             local _hl_start = #variable.name + 3 + depth
             hl.hl_range(hl_group, { line, _hl_start }, { line, -1 })
@@ -120,7 +121,7 @@ M.show = function()
 
             local hl_group = type(response) == "string" and "WatchError"
                 or expr.updated and "WatchUpdated"
-                or response and types_to_hl_group[response.type:lower()]
+                or response and response.type and types_to_hl_group[response.type:lower()]
             if hl_group then
                 local hl_start = #expr_name + 3
                 hl.hl_range(hl_group, { line, hl_start }, { line, -1 })

--- a/lua/dap-view/watches/view.lua
+++ b/lua/dap-view/watches/view.lua
@@ -132,11 +132,19 @@ M.show = function()
 
             line = show_variables_or_err(line, expr)
         end
-        api.nvim_win_set_cursor(state.winnr, { math.max(math.min(cursor_line, line), 1), 1 })
 
+        -- Workaround to reduce jankiness when redrawing
         if line > 0 then
-            api.nvim_buf_set_lines(state.bufnr, line, -1, true, {})
+            local content = {}
+            if cursor_line > line then
+                for i = 1, cursor_line - line do
+                    content[i] = ""
+                end
+            end
+            api.nvim_buf_set_lines(state.bufnr, line, -1, true, content)
         end
+
+        api.nvim_win_set_cursor(state.winnr, { cursor_line, 1 })
     end
 end
 


### PR DESCRIPTION
Closes #33 

![image](https://github.com/user-attachments/assets/0305069f-9b0e-4449-b239-443dc9f0ce0c)

---

## TODO

- [x] Docs

### Bugs

- [x] A race condition with the **JS debug adapter** causes variables to not be evaluated properly when stepping
  
Same as #31, fixed by using `scopes` instead of `event_stopped`

- [x] It's janky AF. ~May resolve that in a follow-up PR.~

It's very that's caused by calling `watches.show()` too often.
Workaround: 98363cf33fcc200c7b6f75fdee8f21a03efafa94

