### PR TITLE
feature: initial experimentation for multi-term/session support

### DIFF
--- a/lua/dap-view/events.lua
+++ b/lua/dap-view/events.lua
@@ -34,12 +34,22 @@ dap.listeners.before.initialize[SUBSCRIPTION_ID] = function(session, _)
     -- However, do not try to delete the buffer on the first session,
     -- as it conflicts with bootstrapping the terminal window.
     -- See: https://github.com/igorlfs/nvim-dap-view/issues/18
-    if state.last_active_adapter and state.last_active_adapter ~= adapter then
-        term.force_delete_term_buf()
-    end
-    state.last_active_adapter = adapter
 
-    term.setup_term_win_cmd()
+    -- if state.last_active_adapter and state.last_active_adapter ~= adapter then
+    --     term.force_delete_term_buf()
+    -- end
+    -- state.last_active_adapter = adapter
+    --
+    -- local separate_term_win = not vim.tbl_contains(setup.config.winbar.sections, "console")
+    -- if not setup.config.windows.terminal.start_hidden and separate_term_win then
+    --     term.open_term_buf_win()
+    -- end
+
+    if not state.term_setup_called then
+        term.setup()
+        state.term_setup_called = true
+    end
+
 
     local separate_term_win = not vim.tbl_contains(setup.config.winbar.sections, "console")
     if not setup.config.windows.terminal.start_hidden and separate_term_win then

--- a/lua/dap-view/state.lua
+++ b/lua/dap-view/state.lua
@@ -8,10 +8,11 @@
 ---@class State
 ---@field bufnr? integer
 ---@field winnr? integer
----@field term_bufnr? integer
+---@field term_bufnrs? {[number]: number}
 ---@field term_winnr? integer
 ---@field last_active_adapter? string
 ---@field subtle_frames boolean
+---@field term_setup_called boolean
 ---@field current_section? SectionType
 ---@field exceptions_options ExceptionsOption[]
 ---@field threads ThreadWithErr[]
@@ -22,6 +23,7 @@
 ---@field variables_by_line table<integer, {response: dap.Variable, reference: number}>
 ---@field watched_expressions table<string,{response?: dap.EvaluateResponse | string, updated?: boolean}>
 local M = {
+    term_bufnrs = {},
     exceptions_options = {},
     threads = {},
     frames_by_line = {},
@@ -29,6 +31,7 @@ local M = {
     variables_by_reference = {},
     variables_by_line = {},
     subtle_frames = false,
+    term_setup_called = false,
     watched_expressions = {},
 }
 

--- a/lua/dap-view/term/init.lua
+++ b/lua/dap-view/term/init.lua
@@ -8,6 +8,19 @@ local M = {}
 
 local api = vim.api
 
+--- @param session dap.Session
+--- @return integer
+M.get_session_buf = function(session)
+    local bufnr = state.term_bufnrs[session.id]
+
+    if bufnr == nil then
+        bufnr = vim.api.nvim_create_buf(true, false)
+        state.term_bufnrs[session.id] = bufnr
+    end
+
+    return bufnr
+end
+
 ---Hide the term win, does not affect the term buffer
 M.hide_term_buf_win = function()
     if state.term_winnr and api.nvim_win_is_valid(state.term_winnr) then
@@ -16,9 +29,10 @@ M.hide_term_buf_win = function()
 end
 
 M.force_delete_term_buf = function()
-    if state.term_bufnr then
-        api.nvim_buf_delete(state.term_bufnr, { force = true })
-    end
+    -- TODO: temporarily commented this out
+    -- if state.term_bufnr then
+    --     api.nvim_buf_delete(state.term_bufnr, { force = true })
+    -- end
 end
 
 ---Open the term buf in a new window if
@@ -28,14 +42,24 @@ end
 ---IV. There's no term win or it is invalid
 ---@return integer?
 M.open_term_buf_win = function()
+    vim.notify("term.open_term_buf_win")
+
     local term_config = setup.config.windows.terminal
     local should_term_be_hidden = vim.tbl_contains(term_config.hide, state.last_active_adapter)
 
-    if dap.session() and state.term_bufnr and not should_term_be_hidden then
+    local session = dap.session()
+    if session == nil then
+        vim.notify("term.open_term_buf_win: no session")
+        return
+    end
+
+    local termbuf = M.get_session_buf(session)
+
+    if termbuf and not should_term_be_hidden then
         if not state.term_winnr or state.term_winnr and not api.nvim_win_is_valid(state.term_winnr) then
             local is_win_valid = state.winnr ~= nil and api.nvim_win_is_valid(state.winnr)
 
-            state.term_winnr = api.nvim_open_win(state.term_bufnr, false, {
+            state.term_winnr = api.nvim_open_win(termbuf, false, {
                 split = is_win_valid and term_config.position or "below",
                 win = is_win_valid and state.winnr or -1,
                 height = setup.config.windows.height,
@@ -43,36 +67,58 @@ M.open_term_buf_win = function()
                     or term_config.width,
             })
 
-            require("dap-view.term.options").set_options(state.term_winnr, state.term_bufnr)
+            require("dap-view.term.options").set_options(state.term_winnr, termbuf)
+        else
+            M.update_term_buf_session(session)
         end
     end
 
     return state.term_winnr
 end
 
-local quit_term_buf = function()
-    if state.term_bufnr then
-        state.term_bufnr = nil
-    end
+--- @param session dap.Session
+M.update_term_buf_session = function(session)
+    local termbuf = M.get_session_buf(session)
+    api.nvim_win_set_buf(state.term_winnr, termbuf)
 end
 
 ---Create the term buf and setup nvim-dap's `terminal_win_cmd` to use it
-M.setup_term_win_cmd = function()
-    if not state.term_bufnr then
-        -- Can't use an unlisted buffer here
-        -- See https://github.com/igorlfs/nvim-dap-view/pull/37#issuecomment-2785076872
-        state.term_bufnr = api.nvim_create_buf(true, false)
+M.setup = function()
+    -- setup terminal_win_cmd to return the correct terminal buffer
+    dap.defaults.fallback.terminal_win_cmd = function(config)
+        vim.notify("terminal_win_cmd")
+        local session = dap.session()
+        assert(session ~= nil, "session is nil, but asking for a terminal?")
 
-        assert(state.term_bufnr ~= 0, "Failed to create nvim-dap-view buffer")
+        vim.notify(vim.inspect(session.id))
+        return M.get_session_buf(session)
+        -- local term_bufnr = api.nvim_create_buf(true, false)
+        -- -- assert(state.term_bufnr ~= 0, "Failed to create nvim-dap-view buffer")
+        -- -- autocmd.quit_buf_autocmd(state.term_bufnr, quit_term_buf)
+        --
+        -- vim.notify("(dap) terminal_win_cmd: " .. term_bufnr)
+        -- return term_bufnr
+    end
 
-        autocmd.quit_buf_autocmd(state.term_bufnr, quit_term_buf)
+    -- wrap dap.set_session so we're "alerted" when the session changes
+    local wrapped_set_session = function(orig_set_session)
+        ---@param new_session dap.Session|nil
+        return function(new_session)
+            orig_set_session(new_session)
+            local _session = dap.session()
+            if _session ~= nil then
+                M.update_term_buf_session(_session)
 
-        dap.defaults.fallback.terminal_win_cmd = function()
-            assert(state.term_bufnr, "Failed to get term bufnr")
-
-            return state.term_bufnr
+                -- horrid
+                local current_section = state.current_section
+                if current_section ~= nil then
+                    require("dap-view." .. current_section .. ".view").show()
+                end
+            end
         end
     end
+
+    dap.set_session = wrapped_set_session(dap.set_session)
 end
 
 return M


### PR DESCRIPTION
Did some experimentation regarding support for multiple terminals. Early proof of concept.

1. Removed `state.term_bufnr` in favour of a table mapping `dap.Session.id` to a terminal buffer number.
2. Added a setup function to the `term` module which sets up the `terminal_win_cmd` callback and sets up a wrapper of `dap.new_session` so we know when the dap session changes. As far as I can tell there's no event for it :(
3. Changes which terminal buffer is displayed in the terminal window on session change
4. Refreshes the current section in a really hacky way (and it's not implemented in the right place anyway)

There's some references still in a couple places to `term_bufnr` which will not be set anymore.

If you want to try changing the active session, this keymap can be used:
```lua
                vim.keymap.set("n", "<space>ds", function()
                    local w = require("dap.ui.widgets")
                    w.sidebar(w.sessions, {}, "5 sp | setl winfixheight").toggle()
                end)
```

The repro steps in issue #50 work fine with this patch.

All mentions of deleting terminal buffers have been commented out, as deleting these buffers doesn't really make sense just because a session was terminated anymore. I suppose it makes most sense to delete/clear buffers if the same configuration gets restarted.

It would also be nice to see names of the sessions you have running. Maybe a winbar on the terminal window?