### PR TITLE
feat(watches): allow add_expr to take custom expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ require("dap-view").close(true) -- Same as `DapViewClose!`
 require("dap-view").toggle()
 require("dap-view").toggle(true) -- Same as `DapViewToggle!`
 require("dap-view").add_expr()
+require("dap-view").add_expr("x + 5") -- Or add a specific expression to watch list
 -- Can be used to jump to a specific view, from any window
 require("dap-view").jump_to_view("[view]")
 -- Can be used to show to a specific view

--- a/lua/dap-view.lua
+++ b/lua/dap-view.lua
@@ -25,8 +25,9 @@ M.toggle = function(hide_terminal)
     actions.toggle(hide_terminal)
 end
 
-M.add_expr = function()
-    actions.add_expr()
+---@param expr? string
+M.add_expr = function(expr)
+    actions.add_expr(expr)
 end
 
 ---@param view SectionType

--- a/lua/dap-view/actions.lua
+++ b/lua/dap-view/actions.lua
@@ -78,8 +78,9 @@ M.open = function()
     autocmd.quit_buf_autocmd(state.bufnr, M.close)
 end
 
-M.add_expr = function()
-    if require("dap-view.watches.actions").add_watch_expr(vim.fn.expand("<cexpr>")) then
+---@param expr? string
+M.add_expr = function(expr)
+    if require("dap-view.watches.actions").add_watch_expr(expr or vim.fn.expand("<cexpr>")) then
         require("dap-view.views").switch_to_view(require("dap-view.watches.view").show)
     end
 end

--- a/lua/dap-view/actions.lua
+++ b/lua/dap-view/actions.lua
@@ -80,7 +80,8 @@ end
 
 ---@param expr? string
 M.add_expr = function(expr)
-    if require("dap-view.watches.actions").add_watch_expr(expr or vim.fn.expand("<cexpr>")) then
+    local final_expr = expr or require("dap-view.util.exprs").get_current_expr()
+    if require("dap-view.watches.actions").add_watch_expr(final_expr) then
         require("dap-view.views").switch_to_view(require("dap-view.watches.view").show)
     end
 end

--- a/lua/dap-view/util/exprs.lua
+++ b/lua/dap-view/util/exprs.lua
@@ -1,23 +1,32 @@
 local M = {}
 
+M.get_selection = function(start, finish)
+    local start_line, start_col = start[2], start[3]
+    local finish_line, finish_col = finish[2], finish[3]
+
+    if start_line > finish_line or (start_line == finish_line and start_col > finish_col) then
+        start_line, start_col, finish_line, finish_col = finish_line, finish_col, start_line, start_col
+    end
+
+    local lines = vim.fn.getline(start_line, finish_line)
+    if #lines == 0 then
+        return ""
+    end
+    if type(lines) == "string" then
+        return lines
+    end
+    lines[#lines] = string.sub(lines[#lines], 1, finish_col)
+    lines[1] = string.sub(lines[1], start_col)
+    return table.concat(lines, '')
+end
+
 M.get_current_expr = function()
-    if vim.fn.mode() == 'v' then
-        local start = vim.fn.getpos('v')
-        local finish = vim.fn.getpos('.')
-        local start_line, start_col = start[2], start[3]
-        local finish_line, finish_col = finish[2], finish[3]
-
-        if start_line > finish_line or (start_line == finish_line and start_col > finish_col) then
-            start_line, start_col, finish_line, finish_col = finish_line, finish_col, start_line, start_col
-        end
-
-        local lines = vim.fn.getline(start_line, finish_line)
-        if #lines == 0 then
-            return ""
-        end
-        lines[#lines] = string.sub(lines[#lines], 1, finish_col)
-        lines[1] = string.sub(lines[1], start_col)
-        return table.concat(lines, ' ')
+    local mode = vim.fn.mode()
+    if mode == 'v' or mode == 'V' then
+        vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<Esc>', false, true, true), 'nx', false)
+        local start = vim.fn.getpos("'<")
+        local finish = vim.fn.getpos("'>")
+        return M.get_selection(start, finish)
     end
     return vim.fn.expand("<cexpr>")
 end

--- a/lua/dap-view/util/exprs.lua
+++ b/lua/dap-view/util/exprs.lua
@@ -1,6 +1,12 @@
 local M = {}
 
-M.get_selection = function(start, finish)
+local api = vim.api
+
+---@return string
+M.get_trimmed_selection = function()
+    local start = vim.fn.getpos("'<")
+    local finish = vim.fn.getpos("'>")
+
     local start_line, start_col = start[2], start[3]
     local finish_line, finish_col = finish[2], finish[3]
 
@@ -12,22 +18,41 @@ M.get_selection = function(start, finish)
     if #lines == 0 then
         return ""
     end
-    if type(lines) == "string" then
-        return lines
+
+    -- It's easier to manipulate a single line as if it were a string
+    if #lines == 1 then
+        lines = lines[1]
     end
-    lines[#lines] = string.sub(lines[#lines], 1, finish_col)
+
+    if type(lines) == "string" then
+        return string.sub(lines, start_col, finish_col)
+    end
+
     lines[1] = string.sub(lines[1], start_col)
-    return table.concat(lines, '')
+    lines[#lines] = string.sub(lines[#lines], 1, finish_col)
+
+    -- Trim to simplify final expression
+    local trimmed_lines = vim.iter(lines)
+        :map(function(line)
+            return vim.trim(line)
+        end)
+        :totable()
+
+    return table.concat(trimmed_lines, "")
 end
 
+---@return string
 M.get_current_expr = function()
     local mode = vim.fn.mode()
-    if mode == 'v' or mode == 'V' then
-        vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<Esc>', false, true, true), 'nx', false)
-        local start = vim.fn.getpos("'<")
-        local finish = vim.fn.getpos("'>")
-        return M.get_selection(start, finish)
+
+    if mode == "v" or mode == "V" then
+        -- Return to normal mode
+        local keys = api.nvim_replace_termcodes("<Esc>", true, true, true)
+        api.nvim_feedkeys(keys, "x", false)
+
+        return M.get_trimmed_selection()
     end
+
     return vim.fn.expand("<cexpr>")
 end
 

--- a/lua/dap-view/util/exprs.lua
+++ b/lua/dap-view/util/exprs.lua
@@ -1,0 +1,25 @@
+local M = {}
+
+M.get_current_expr = function()
+    if vim.fn.mode() == 'v' then
+        local start = vim.fn.getpos('v')
+        local finish = vim.fn.getpos('.')
+        local start_line, start_col = start[2], start[3]
+        local finish_line, finish_col = finish[2], finish[3]
+
+        if start_line > finish_line or (start_line == finish_line and start_col > finish_col) then
+            start_line, start_col, finish_line, finish_col = finish_line, finish_col, start_line, start_col
+        end
+
+        local lines = vim.fn.getline(start_line, finish_line)
+        if #lines == 0 then
+            return ""
+        end
+        lines[#lines] = string.sub(lines[#lines], 1, finish_col)
+        lines[1] = string.sub(lines[1], start_col)
+        return table.concat(lines, ' ')
+    end
+    return vim.fn.expand("<cexpr>")
+end
+
+return M

--- a/plugin/dap-view.lua
+++ b/plugin/dap-view.lua
@@ -10,18 +10,15 @@ command("DapViewToggle", function(opts)
     require("dap-view").toggle(opts.bang)
 end, { bang = true })
 command("DapViewWatch", function(opts)
-    if opts.range then
-        local start = vim.fn.getpos("'<")
-        local finish = vim.fn.getpos("'>")
-        local expr = require('dap-view.util.exprs').get_selection(start, finish)
-        require("dap-view").add_expr(expr)
-    elseif #opts.fargs == 0 then
-        require("dap-view").add_expr()
-    else
-        require("dap-view").add_expr(table.concat(opts.fargs, ' '))
+    local expr = nil
+    if opts.range > 0 then
+        expr = require("dap-view.util.exprs").get_trimmed_selection()
+    elseif #opts.fargs > 0 then
+        expr = table.concat(opts.fargs, " ")
     end
+    require("dap-view").add_expr(expr)
 end, {
-    nargs = '*',
+    nargs = "*",
     range = true,
 })
 command("DapViewJump", function(opts)

--- a/plugin/dap-view.lua
+++ b/plugin/dap-view.lua
@@ -9,9 +9,21 @@ end, { bang = true })
 command("DapViewToggle", function(opts)
     require("dap-view").toggle(opts.bang)
 end, { bang = true })
-command("DapViewWatch", function()
-    require("dap-view").add_expr()
-end, {})
+command("DapViewWatch", function(opts)
+    if opts.range then
+        local start = vim.fn.getpos("'<")
+        local finish = vim.fn.getpos("'>")
+        local expr = require('dap-view.util.exprs').get_selection(start, finish)
+        require("dap-view").add_expr(expr)
+    elseif #opts.fargs == 0 then
+        require("dap-view").add_expr()
+    else
+        require("dap-view").add_expr(table.concat(opts.fargs, ' '))
+    end
+end, {
+    nargs = '*',
+    range = true,
+})
 command("DapViewJump", function(opts)
     require("dap-view").jump_to_view(opts.fargs[1])
 end, {


### PR DESCRIPTION
Sometimes you need to add custom expressions to the watch list. For example, in codelldb, you can supply "/nat" prefix to change the evaluation mechanism of expression.

This PR adds this capability by allowing an optional `expr` string in `require('dap-view').add_expr`

However, this PR still doesn't change to user command behavior (it still doesn't take an argument), since there is some decision to make on how to supply the expression: either it has to ask user to wrap the expression inside the string (and take a single argument), or it can concatenate all given arguments into a single string.