### PR TITLE
feat(windows): anchor main window to another window

### DIFF
--- a/lua/dap-view/actions.lua
+++ b/lua/dap-view/actions.lua
@@ -57,10 +57,12 @@ M.open = function()
     local windows_config = setup.config.windows
 
     local term_position = require("dap-view.util").inverted_directions[windows_config.terminal.position]
+    local anchor_win = windows_config.anchor and windows_config.anchor()
+    local is_anchor_win_valid = anchor_win and api.nvim_win_is_valid(anchor_win)
 
     local winnr = api.nvim_open_win(bufnr, false, {
-        split = is_term_win_valid and term_position or windows_config.position,
-        win = is_term_win_valid and term_winnr or -1,
+        split = (is_anchor_win_valid or is_term_win_valid) and term_position or windows_config.position,
+        win = is_anchor_win_valid and anchor_win or is_term_win_valid and term_winnr or -1,
         height = windows_config.height < 1 and math.floor(vim.go.lines * windows_config.height)
             or windows_config.height,
     })

--- a/lua/dap-view/config.lua
+++ b/lua/dap-view/config.lua
@@ -15,6 +15,7 @@ local M = {}
 ---@class dapview.WindowsConfig
 ---@field height integer If > 1 number of lines, else percentage the windows should use
 ---@field position 'right' | 'left' | 'above' | 'below'
+---@field anchor? fun(): integer? Function that returns a window number for the main nvim-dap-view window to follow
 ---@field terminal dapview.TerminalConfig
 
 ---@class dapview.WinbarHeaders

--- a/lua/dap-view/setup/validate/help.lua
+++ b/lua/dap-view/setup/validate/help.lua
@@ -5,13 +5,7 @@ function M.validate(config)
     local validate = require("dap-view.setup.validate.util").validate
 
     validate("help", {
-        border = {
-            config.border,
-            function(v)
-                return v == nil or type(v) == "string" or type(v) == "table"
-            end,
-            "string|string[]|nil",
-        },
+        border = { config.border, { "string", "table", "nil" } },
     }, config)
 end
 

--- a/lua/dap-view/setup/validate/windows.lua
+++ b/lua/dap-view/setup/validate/windows.lua
@@ -8,6 +8,7 @@ function M.validate(config)
         height = { config.height, "number" },
         position = { config.position, "string" },
         terminal = { config.terminal, "table" },
+        anchor = { config.anchor, { "function", "nil" } },
     }, config)
 
     validate("windows.terminal", {


### PR DESCRIPTION
Closes #60,
Closes #18

An alternative to "adding a terminal window to the main window".

Allows the user to define a function that returns a window number for the main window to track (aka "follow"), **overriding the tracking of the regular terminal**.

Coupled with the option to hide the terminal for some adapters, allows a seamless experience for Go debugging when remote attaching with delve.

## Config:

```lua
    opts = {
        windows = {
            terminal = {
                hide = { "delve" },
            },
            anchor = function()
                -- proof of concept, can be tweaked 
                local windows = vim.api.nvim_tabpage_list_wins(0)

                for _, win in ipairs(windows) do
                    local bufnr = vim.api.nvim_win_get_buf(win)
                    if vim.bo[bufnr].buftype == "terminal" then
                        return win
                    end
                end
            end,
        },
    },
```

## Demo

https://github.com/user-attachments/assets/5dce4b3d-fc01-4be6-9a72-b0f969e34b14

@231tr0n let me know if this suffices for your use case.
