### PR TITLE
fix: locally set window options

### DIFF
--- a/lua/dap-view/views/init.lua
+++ b/lua/dap-view/views/init.lua
@@ -9,13 +9,13 @@ local api = vim.api
 ---@param message string
 M.cleanup_view = function(cond, message)
     if cond then
-        vim.wo[state.winnr].cursorline = false
+        vim.wo[state.winnr][0].cursorline = false
 
         api.nvim_buf_set_lines(state.bufnr, 0, -1, false, { message })
 
         hl.hl_range("MissingData", { 0, 0 }, { 0, #message })
     else
-        vim.wo[state.winnr].cursorline = true
+        vim.wo[state.winnr][0].cursorline = true
     end
 
     return cond

--- a/lua/dap-view/views/keymaps/docs.lua
+++ b/lua/dap-view/views/keymaps/docs.lua
@@ -61,11 +61,11 @@ M.show_help = function()
     vim.bo[help_buf].filetype = "dap-view-help"
     vim.bo[help_buf].modifiable = false
 
-    vim.wo[help_win].conceallevel = 2
-    vim.wo[help_win].concealcursor = "nvc"
+    vim.wo[help_win][0].conceallevel = 2
+    vim.wo[help_win][0].concealcursor = "nvc"
 
-    vim.wo[help_win].cursorline = true
-    vim.wo[help_win].cursorlineopt = "line"
+    vim.wo[help_win][0].cursorline = true
+    vim.wo[help_win][0].cursorlineopt = "line"
 
     api.nvim_create_autocmd("WinClosed", {
         buffer = help_buf,


### PR DESCRIPTION
Problem:
Windows options like cursorline propagate to new windows split from the dap-view window.

Solution:
Index vim.wo additionally with bufnr=0 for :setlocal behavior.