### PR TITLE
fix: properly handle buffer deletion

### DIFF
--- a/lua/dap-view/actions.lua
+++ b/lua/dap-view/actions.lua
@@ -27,12 +27,12 @@ M.close = function(hide_terminal)
     end
     if state.winnr and api.nvim_win_is_valid(state.winnr) then
         api.nvim_win_close(state.winnr, true)
-        state.winnr = nil
     end
-    if state.bufnr then
+    state.winnr = nil
+    if state.bufnr and api.nvim_buf_is_valid(state.bufnr) then
         api.nvim_buf_delete(state.bufnr, { force = true })
-        state.bufnr = nil
     end
+    state.bufnr = nil
     if hide_terminal then
         term.hide_term_buf_win()
     end
@@ -80,8 +80,12 @@ M.open = function()
     winbar.set_winbar_action_keymaps()
     winbar.show_content(state.current_section)
 
-    -- Properly handle deleting the buffer
-    autocmd.quit_buf_autocmd(state.bufnr, M.close)
+    -- Clean up states dap-view buffer is wiped out
+    autocmd.quit_buf_autocmd(state.bufnr, function()
+        -- The buffer is already being wiped out, so prevent close() from doing it again.
+        state.bufnr = nil
+        M.close()
+    end)
 end
 
 ---@param expr? string

--- a/lua/dap-view/options/autocmd.lua
+++ b/lua/dap-view/options/autocmd.lua
@@ -5,7 +5,7 @@ local api = vim.api
 ---@param bufnr integer
 ---@param callback fun(): nil
 M.quit_buf_autocmd = function(bufnr, callback)
-    api.nvim_create_autocmd("BufDelete", {
+    api.nvim_create_autocmd("BufWipeout", {
         buffer = bufnr,
         callback = callback,
     })


### PR DESCRIPTION
Problems
* If dap-view buffer is :bwipeout-ed, subsequent close() raises invalid buffer error while attempting to nvim_buf_delete (= bwipeout) the buffer because the buffer is not removed from the state.
* quit_buf_autocmd is weird. BufDelete is invoked when a buffer becomes unlisted. So, since dap-view buffer is already unlisted, closing it with commands like :q does not invoke the BufDelete autocmd.

Solution:
* Let close() check the validity of the buffer first.
* Use BufWipeout autocmd.
* Let the BufWipeout callback first remove the buffer from dap-view state to avoid deleting the buffer inside BufWipeout (E937).