### PR TITLE
fix: minor issues with buf/win state management

### DIFF
--- a/lua/dap-view/autocmds.lua
+++ b/lua/dap-view/autocmds.lua
@@ -48,7 +48,10 @@ api.nvim_create_autocmd("TabEnter", {
 api.nvim_create_autocmd("BufEnter", {
     callback = function(args)
         local buf = args.buf
-        local win = vim.fn.bufwinid(buf)
+        if not api.nvim_buf_is_valid(buf) then
+            return
+        end
+        local win = api.nvim_get_current_win()
         local ft = vim.bo[buf].filetype
 
         -- Reset the winnr if the buffer changed
@@ -63,8 +66,11 @@ api.nvim_create_autocmd("BufEnter", {
             if not vim.tbl_contains({ "dap-view", "dap-view-term", "dap-repl" }, ft) then
                 state.winnr = nil
             end
+        elseif not state.winnr and vim.tbl_contains({ "dap-view", "dap-repl" }, ft) then
+            state.winnr = win
         end
-        -- For good measure, also handle term_winr
+
+        -- For good measure, also handle term_winnr
         if state.term_winnr == win and ft ~= "dap-view-term" then
             state.term_winnr = nil
         end

--- a/lua/dap-view/autocmds.lua
+++ b/lua/dap-view/autocmds.lua
@@ -66,8 +66,13 @@ api.nvim_create_autocmd("BufEnter", {
             if not vim.tbl_contains({ "dap-view", "dap-view-term", "dap-repl" }, ft) then
                 state.winnr = nil
             end
-        elseif not state.winnr and vim.tbl_contains({ "dap-view", "dap-repl" }, ft) then
-            state.winnr = win
+        elseif not state.winnr then
+            if
+                vim.tbl_contains({ "dap-view", "dap-repl" }, ft)
+                or (ft == "dap-view-term" and state.current_section == "console")
+            then
+                state.winnr = win
+            end
         end
 
         -- For good measure, also handle term_winnr


### PR DESCRIPTION
* Problem: A buffer being entered may have become invalid, if there is a BufEnter that `:bwipeout`s that buffer. For example, vim-fern-hijack does this.
  * Solution: Check validity of buffer.
* Problem: `state.winnr` can be nil even when ther current window is dap-view window, if the user opened the dap-view buffer with some other method, e.g., CTRL-O.
  * Solution: Set `state.winnr` on BufEnter.
* Comment: Maybe we can avoid these kind of problem altogether by setting winfixbuf. The problem "can't use winfixbuf since the window shares many buffers" can be circumvented by temporarily unsetting winfixbuf.