### PR TITLE
feat(ui): add customization for inactive winbar header

### DIFF
--- a/lua/dap-view/config.lua
+++ b/lua/dap-view/config.lua
@@ -54,6 +54,7 @@ local M = {}
 ---@field default_section dapview.SectionType
 ---@field show boolean
 ---@field headers dapview.WinbarHeaders Header label for each section.
+---@field headers_inactive dapview.WinbarHeaders
 ---@field controls dapview.ControlsConfig
 
 ---@class dapview.HelpConfig
@@ -73,13 +74,22 @@ M.config = {
         sections = { "watches", "scopes", "exceptions", "breakpoints", "threads", "repl" },
         default_section = "watches",
         headers = {
-            breakpoints = "Breakpoints [B]",
-            scopes = "Scopes [S]",
-            exceptions = "Exceptions [E]",
-            watches = "Watches [W]",
-            threads = "Threads [T]",
-            repl = "REPL [R]",
-            console = "Console [C]",
+            breakpoints = "Breakpoints",
+            scopes = "Scopes",
+            exceptions = "Exceptions",
+            watches = "Watches",
+            threads = "Threads",
+            repl = "REPL",
+            console = "Console",
+        },
+        headers_inactive = {
+            breakpoints = " [B]",
+            scopes = "󰂥 [S]",
+            exceptions = "󰢃 [E]",
+            watches = "󰛐 [W]",
+            threads = "󱉯 [T]",
+            repl = "󰯃 [R]",
+            console = "󰆍 [C]",
         },
         controls = {
             enabled = false,

--- a/lua/dap-view/options/winbar.lua
+++ b/lua/dap-view/options/winbar.lua
@@ -122,10 +122,13 @@ local set_winbar_opt = function()
             local info = winbar_info[key]
 
             if info ~= nil then
-                local desc = " " .. setup.config.winbar.headers[key] .. " "
+                local is_current_section = state.current_section == key
+                local wb = setup.config.winbar
+                local header = is_current_section and wb.headers[key] or wb.headers_inactive[key]
+                local desc = " " .. header .. " "
                 desc = statusline.clickable(desc, module, "on_click", idx)
 
-                if state.current_section == key then
+                if is_current_section then
                     desc = statusline.hl(desc, "TabSelected")
                 else
                     desc = statusline.hl(desc, "Tab")

--- a/lua/dap-view/setup/validate/winbar.lua
+++ b/lua/dap-view/setup/validate/winbar.lua
@@ -9,6 +9,7 @@ function M.validate(config)
         sections = { config.sections, "table" },
         default_section = { config.default_section, "string" },
         headers = { config.headers, "table" },
+        headers_inactive = { config.headers_inactive, "table" },
         controls = { config.controls, "table" },
     }, config)
 
@@ -21,6 +22,16 @@ function M.validate(config)
         repl = { config.headers.repl, "string" },
         console = { config.headers.console, "string" },
     }, config.headers)
+
+    validate("winbar.headers_inactive", {
+        breakpoints = { config.headers_inactive.breakpoints, "string" },
+        scopes = { config.headers_inactive.scopes, "string" },
+        exceptions = { config.headers_inactive.exceptions, "string" },
+        watches = { config.headers_inactive.watches, "string" },
+        threads = { config.headers_inactive.threads, "string" },
+        repl = { config.headers_inactive.repl, "string" },
+        console = { config.headers_inactive.console, "string" },
+    }, config.headers_inactive)
 
     validate("winbar.controls", {
         enabled = { config.controls.enabled, "boolean" },


### PR DESCRIPTION
This PR makes the display of inactive winbar headers configurable.

By default, inactive items now display Nerd font icons only. This helps reduce space usage and prevents truncation.
This is especially useful in constrained layouts such as split views or on small screens.