### PR TITLE
fix(term): Schedule cursor setting for autoscroll

### DIFF
--- a/lua/dap-view/term/scroll.lua
+++ b/lua/dap-view/term/scroll.lua
@@ -30,7 +30,10 @@ M.scroll = function(bufnr)
             if autoscroll and vim.fn.mode() == "n" then
                 api.nvim_win_call(state.term_winnr, function()
                     if api.nvim_get_current_buf() == bufnr then
-                        api.nvim_win_set_cursor(state.term_winnr, { api.nvim_buf_line_count(bufnr), 1 })
+                        -- vim.schedule ensures the cursor movement happens in the main event loop.
+                        vim.schedule(function()
+                            api.nvim_win_set_cursor(state.term_winnr, { api.nvim_buf_line_count(bufnr), 0 })
+                        end)
                     end
                 end)
             end


### PR DESCRIPTION
Sets the cursor to the beginning of the line (column 0 - for empty lines) when autoscrolling in the DAP view terminal, and schedules the cursor setting using `vim.schedule` to run the update in the main thread.