### PR TITLE
fix: delete terminal buffer on disconnect

### DIFF
--- a/lua/dap-view/events.lua
+++ b/lua/dap-view/events.lua
@@ -142,7 +142,9 @@ dap.listeners.after.initialize[SUBSCRIPTION_ID] = function(session)
     end
 end
 
-dap.listeners.after.event_terminated[SUBSCRIPTION_ID] = function(session)
+local cleanup_events = { "disconnect", "terminated" }
+
+local function cleanup(session)
     -- Refresh threads view on exit to avoid showing outdated trace
     if state.current_section == "threads" then
         threads.show()
@@ -173,8 +175,12 @@ dap.listeners.after.event_terminated[SUBSCRIPTION_ID] = function(session)
     winbar.redraw_controls()
 end
 
+for _, event in ipairs(cleanup_events) do
+    dap.listeners.after[event][SUBSCRIPTION_ID] = cleanup
+end
+
 --- Refresh winbar on dap session state change events not having a dedicated event handler
-local winbar_redraw_events = { "continue", "disconnect", "event_exited", "event_stopped", "restart" }
+local winbar_redraw_events = { "continue", "event_exited", "event_stopped", "restart" }
 
 for _, event in ipairs(winbar_redraw_events) do
     dap.listeners.after[event][SUBSCRIPTION_ID] = winbar.redraw_controls


### PR DESCRIPTION
Problem:
If the debug adapter doesn't have supportsTerminateRequest capability (e.g., OpenDebugAD7 from cpptools), terminating the debuggy doesn't fire "terminated" event. So the terminal buffer for debuggy is not deleted by dap-view's event handler, and remains pooled by nvim-dap. A subsequent session reuses this terminal buffer, which is not expected by dap-view's terminal lifecycle management. As a result the user ends up seeing empty buffer created by dap-view, while the actual terminal buffer is hidden.

Solution:
Reuse the cleanup logic of the "terminated"-handler on "disconnect"-handler.