### PR TITLE
fix: fix autoscroll in case of early terminal focus

### DIFF
--- a/lua/dap-view/console/scroll.lua
+++ b/lua/dap-view/console/scroll.lua
@@ -5,51 +5,85 @@ local state = require("dap-view.state")
 local M = {}
 
 local api = vim.api
-
-local autoscroll = true
+local termbuf_is_autoscrolling = {}
 
 -- Inspired by nvim-dap-ui
 -- https://github.com/rcarriga/nvim-dap-ui/blob/73a26abf4941aa27da59820fd6b028ebcdbcf932/lua/dapui/elements/console.lua#L23-L46
 
+---@return integer?
+M.get_winnr = function()
+    local winnr = vim.tbl_contains(setup.config.winbar.sections, "console") and state.winnr or state.term_winnr
+
+    if not util.is_win_valid(winnr) then
+        return nil
+    end
+
+    return winnr
+end
+
 ---@param bufnr integer
 M.setup_autoscroll = function(bufnr)
+    termbuf_is_autoscrolling[bufnr] = true
+
+    -- BUG: since term buffers seem to be re-used for restarted sessions
+    -- this autocmd gets recreated for each restart
     api.nvim_create_autocmd({ "InsertEnter", "CursorMoved" }, {
         buffer = bufnr,
-        callback = function()
-            local winnr = vim.tbl_contains(setup.config.winbar.sections, "console") and state.winnr or state.term_winnr
-            if util.is_win_valid(winnr) then
-                ---@cast winnr integer
-                local cursor = api.nvim_win_get_cursor(winnr)
-                autoscroll = cursor[1] == api.nvim_buf_line_count(bufnr)
+        callback = function(args)
+            local winnr = M.get_winnr()
+            if winnr == nil then
+                return
             end
+
+            ---@cast winnr integer
+            local cursor = api.nvim_win_get_cursor(winnr)
+            termbuf_is_autoscrolling[bufnr] = cursor[1] == api.nvim_buf_line_count(bufnr)
+
+            vim.notify(vim.inspect({
+                args.event,
+                cursor[1],
+                api.nvim_buf_line_count(bufnr),
+                termbuf_is_autoscrolling[bufnr],
+            }))
         end,
     })
 
     api.nvim_buf_attach(bufnr, false, {
         on_lines = function()
-            M.trigger_autoscroll(bufnr)
+            local winnr = M.get_winnr()
+            if winnr == nil then
+                return
+            end
+
+            ---@cast winnr integer
+            if M.is_autoscrolling(bufnr) and vim.fn.mode() == "n" then
+                api.nvim_win_call(winnr, function()
+                    if api.nvim_get_current_buf() == bufnr then
+                        M.set_cursor_bottom(winnr, bufnr)
+                    end
+                end)
+            end
         end,
     })
 end
 
+M.is_autoscrolling = function(bufnr)
+    return termbuf_is_autoscrolling[bufnr]
+end
+
+M.set_cursor_bottom = function(winnr, bufnr)
+    -- vim.schedule ensures the cursor movement happens in the main event loop
+    -- otherwise the call may happen too early
+    vim.schedule(function()
+        api.nvim_win_set_cursor(winnr, { api.nvim_buf_line_count(bufnr), 0 })
+        termbuf_is_autoscrolling[bufnr] = true
+    end)
+end
+
+-- NOTE: not sure where this should be called - is an autocmd necessary for this?
 ---@param bufnr integer
-M.trigger_autoscroll = function(bufnr)
-    local winnr = vim.tbl_contains(setup.config.winbar.sections, "console") and state.winnr or state.term_winnr
-    if not util.is_win_valid(winnr) then
-        return
-    end
-    ---@cast winnr integer
-    if autoscroll and vim.fn.mode() == "n" then
-        api.nvim_win_call(winnr, function()
-            if api.nvim_get_current_buf() == bufnr then
-                -- vim.schedule ensures the cursor movement happens in the main event loop
-                -- otherwise the call may happen too early
-                vim.schedule(function()
-                    api.nvim_win_set_cursor(winnr, { api.nvim_buf_line_count(bufnr), 0 })
-                end)
-            end
-        end)
-    end
+M.cleanup_autoscroll = function(bufnr)
+    table.remove(termbuf_is_autoscrolling, bufnr)
 end
 
 return M

--- a/lua/dap-view/console/scroll.lua
+++ b/lua/dap-view/console/scroll.lua
@@ -29,7 +29,7 @@ M.setup_autoscroll = function(bufnr)
     -- this autocmd gets recreated for each restart
     api.nvim_create_autocmd({ "InsertEnter", "CursorMoved" }, {
         buffer = bufnr,
-        callback = function(args)
+        callback = function()
             local winnr = M.get_winnr()
             if winnr == nil then
                 return
@@ -38,13 +38,6 @@ M.setup_autoscroll = function(bufnr)
             ---@cast winnr integer
             local cursor = api.nvim_win_get_cursor(winnr)
             termbuf_is_autoscrolling[bufnr] = cursor[1] == api.nvim_buf_line_count(bufnr)
-
-            vim.notify(vim.inspect({
-                args.event,
-                cursor[1],
-                api.nvim_buf_line_count(bufnr),
-                termbuf_is_autoscrolling[bufnr],
-            }))
         end,
     })
 

--- a/lua/dap-view/console/scroll.lua
+++ b/lua/dap-view/console/scroll.lua
@@ -27,24 +27,29 @@ M.scroll = function(bufnr)
 
     api.nvim_buf_attach(bufnr, false, {
         on_lines = function()
-            local winnr = vim.tbl_contains(setup.config.winbar.sections, "console") and state.winnr or state.term_winnr
-            if not util.is_win_valid(winnr) then
-                return
-            end
-            ---@cast winnr integer
-            if autoscroll and vim.fn.mode() == "n" then
-                api.nvim_win_call(winnr, function()
-                    if api.nvim_get_current_buf() == bufnr then
-                        -- vim.schedule ensures the cursor movement happens in the main event loop
-                        -- otherwise the call may happen too early
-                        vim.schedule(function()
-                            api.nvim_win_set_cursor(winnr, { api.nvim_buf_line_count(bufnr), 0 })
-                        end)
-                    end
-                end)
-            end
+            M.setup_buf(bufnr)
         end,
     })
+end
+
+---@param bufnr integer
+M.setup_buf = function(bufnr)
+    local winnr = vim.tbl_contains(setup.config.winbar.sections, "console") and state.winnr or state.term_winnr
+    if not util.is_win_valid(winnr) then
+        return
+    end
+    ---@cast winnr integer
+    if autoscroll and vim.fn.mode() == "n" then
+        api.nvim_win_call(winnr, function()
+            if api.nvim_get_current_buf() == bufnr then
+                -- vim.schedule ensures the cursor movement happens in the main event loop
+                -- otherwise the call may happen too early
+                vim.schedule(function()
+                    api.nvim_win_set_cursor(winnr, { api.nvim_buf_line_count(bufnr), 0 })
+                end)
+            end
+        end)
+    end
 end
 
 return M

--- a/lua/dap-view/console/scroll.lua
+++ b/lua/dap-view/console/scroll.lua
@@ -60,10 +60,13 @@ M.setup_autoscroll = function(bufnr)
     })
 end
 
+---@param bufnr integer
 M.is_autoscrolling = function(bufnr)
     return termbuf_is_autoscrolling[bufnr]
 end
 
+---@param winnr integer
+---@param bufnr integer
 M.set_cursor_bottom = function(winnr, bufnr)
     -- vim.schedule ensures the cursor movement happens in the main event loop
     -- otherwise the call may happen too early

--- a/lua/dap-view/console/scroll.lua
+++ b/lua/dap-view/console/scroll.lua
@@ -12,7 +12,7 @@ local autoscroll = true
 -- https://github.com/rcarriga/nvim-dap-ui/blob/73a26abf4941aa27da59820fd6b028ebcdbcf932/lua/dapui/elements/console.lua#L23-L46
 
 ---@param bufnr integer
-M.scroll = function(bufnr)
+M.setup_autoscroll = function(bufnr)
     api.nvim_create_autocmd({ "InsertEnter", "CursorMoved" }, {
         buffer = bufnr,
         callback = function()
@@ -27,13 +27,13 @@ M.scroll = function(bufnr)
 
     api.nvim_buf_attach(bufnr, false, {
         on_lines = function()
-            M.setup_buf(bufnr)
+            M.trigger_autoscroll(bufnr)
         end,
     })
 end
 
 ---@param bufnr integer
-M.setup_buf = function(bufnr)
+M.trigger_autoscroll = function(bufnr)
     local winnr = vim.tbl_contains(setup.config.winbar.sections, "console") and state.winnr or state.term_winnr
     if not util.is_win_valid(winnr) then
         return

--- a/lua/dap-view/console/view.lua
+++ b/lua/dap-view/console/view.lua
@@ -74,9 +74,11 @@ M.show = function()
         vim.wo[state.winnr][0].winfixbuf = true
     end)
 
-    -- if the autoscrolling state was true, re-set the cursor position
-    if winnr ~= nil and is_autoscrolling then
-        scroll.set_cursor_bottom(winnr, term_buf)
+    -- When showing a session for the first time, assume the user wants autoscroll to just work™
+    -- That's necessary because when a terminal buffer is created, the number of lines is assigned to the number of
+    -- lines in the window. This may lead to autoscroll being set to false, since the user may not be "at the bottom".
+    if is_autoscrolling then
+        scroll.scroll_to_bottom(state.winnr, term_buf)
     end
 end
 
@@ -154,6 +156,7 @@ M.setup_term_buf = function()
     end
 
     require("dap-view.console.keymaps").set_keymaps(term_bufnr)
+
     scroll.setup_autoscroll(term_bufnr)
 end
 


### PR DESCRIPTION
Fixes an issue where the `CursorMoved` autocmd will run before the `on_lines` handler and set `autoscroll = false` in the case of the user focusing on the terminal before any output, resulting in broken autoscrolling.

Discussion: https://github.com/igorlfs/nvim-dap-view/discussions/109#discussioncomment-14348344