### PR TITLE
#125 Handle terminal lock-in

### DIFF
--- a/docs/src/routes/configuration/+page.md
+++ b/docs/src/routes/configuration/+page.md
@@ -119,6 +119,10 @@ return {
             start_hidden = true,
         },
     },
+    console = {
+        -- Capture <C-c> to unfocus the window instead of aborting the terminal process
+        capture_ctrl_c = true,
+    },
     icons = {
         disabled = "",
         disconnect = "",

--- a/lua/dap-view/config.lua
+++ b/lua/dap-view/config.lua
@@ -69,10 +69,14 @@ local M = {}
 ---@class dapview.HelpConfig
 ---@field border? string|string[] Override `winborder` in the help window
 
+---@class dapview.ConsoleConfig
+---@field capture_ctrl_c boolean
+
 ---@class (exact) dapview.ConfigStrict
 ---@field winbar dapview.WinbarConfig
 ---@field windows dapview.WindowsConfig
 ---@field help dapview.HelpConfig
+---@field console dapview.ConsoleConfig
 ---@field icons dapview.IconsConfig Icons for each button
 ---@field switchbuf string|dapview.SwitchBufFun Control how to jump when selecting a breakpoint or a call in the stack
 ---@field auto_toggle boolean|"keep_terminal"
@@ -194,6 +198,9 @@ M.config = {
     },
     help = {
         border = nil,
+    },
+    console = {
+        capture_ctrl_c = true,
     },
     switchbuf = "usetab,uselast",
     auto_toggle = false,

--- a/lua/dap-view/console/keymaps.lua
+++ b/lua/dap-view/console/keymaps.lua
@@ -1,4 +1,5 @@
 local keymap = require("dap-view.views.keymaps.util").keymap
+local setup = require("dap-view.setup")
 
 local M = {}
 
@@ -11,6 +12,21 @@ M.set_keymaps = function(buf)
     keymap("[s", function()
         require("dap-view").navigate({ count = -vim.v.count1, wrap = true, type = "sessions" })
     end, buf)
+
+    require("dap-view.options.winbar").set_action_keymaps(buf)
+
+    local console_config = setup.config.console
+
+    if not console_config.capture_ctrl_c then
+        return
+    end
+
+    vim.keymap.set("t", "<C-c>", function()
+        local term_escape = vim.api.nvim_replace_termcodes("<C-\\><C-n>", true, false, true)
+        vim.api.nvim_feedkeys(term_escape, "n", false)
+
+        require("dap-view.options.winbar").refresh_winbar("console")
+    end, { desc = "Exit terminal mode" })
 end
 
 return M

--- a/lua/dap-view/console/view.lua
+++ b/lua/dap-view/console/view.lua
@@ -11,6 +11,7 @@ local scroll = require("dap-view.console.scroll")
 local M = {}
 
 local api = vim.api
+local log = vim.log.levels
 
 ---Workaround to fetch the term_buf for sessions created via `startDebugging` from js-debug-adapter
 ---Only the top-level session owns the buf, children need to traverse parents to get it
@@ -57,6 +58,13 @@ M.show = function()
 
     ---`cleanup_view` ensures the buffer exists
     ---@cast term_buf integer
+
+    if not util.is_buf_valid(term_buf) then
+        vim.notify("Terminal buffer is invalid: " .. term_buf, log.ERROR)
+        return
+    end
+
+    require("dap-view.console.keymaps").set_keymaps(term_buf)
 
     local is_autoscrolling = scroll.is_autoscrolling(term_buf)
 

--- a/lua/dap-view/setup/validate/console.lua
+++ b/lua/dap-view/setup/validate/console.lua
@@ -1,0 +1,12 @@
+local M = {}
+
+local validate = require("dap-view.setup.validate.util").validate
+
+---@param config dapview.ConsoleConfig
+function M.validate(config)
+    validate("console", {
+        capture_ctrl_c = { config.capture_ctrl_c, "boolean" },
+    }, config)
+end
+
+return M

--- a/lua/dap-view/setup/validate/init.lua
+++ b/lua/dap-view/setup/validate/init.lua
@@ -6,6 +6,7 @@ function M.validate(config)
         windows = { config.windows, "table" },
         winbar = { config.winbar, "table" },
         help = { config.help, "table" },
+        console = { config.console, "table" },
         switchbuf = { config.switchbuf, { "string", "function" } },
         icons = { config.icons, "table" },
         auto_toggle = { config.auto_toggle, { "boolean", "string" } },
@@ -20,6 +21,7 @@ function M.validate(config)
     require("dap-view.setup.validate.windows").validate(config.windows)
     require("dap-view.setup.validate.help").validate(config.help)
     require("dap-view.setup.validate.icons").validate(config.icons)
+    require("dap-view.setup.validate.console").validate(config.console)
 end
 
 return M

--- a/lua/dap-view/types.lua
+++ b/lua/dap-view/types.lua
@@ -15,8 +15,11 @@
 
 ---@class dapview.HelpConfigPartial : dapview.HelpConfig, {}
 
+---@class dapview.ConsoleConfigPartial : dapview.ConsoleConfig, {}
+
 ---@class dapview.Config : dapview.ConfigStrict, {}
 ---@field winbar? dapview.WinbarConfigPartial
 ---@field windows? dapview.WindowsConfigPartial
 ---@field help? dapview.HelpConfigPartial
 ---@field icons? dapview.IconsConfigPartial
+---@field console? dapview.ConsoleConfigPartial


### PR DESCRIPTION
This PR addresses the console-related issues described in issue #125:

### Summary 
- Fixed console window lock-in through applying the keymaps to the terminal buffer
- Added new config option 'capture_ctrl_c' to remap 'C-c' to '<C-\\><C-n>' to avoid termination and escape the terminal
- Handled the case leading to described "invalid terminal buffer" error message more gracefully

### Testing
- Verified that focusing the console no longer blocks window switching
- Confirmed desired behavior for capture_ctrl_c