### PR TITLE
feat(highlight): Do not force override highlight groups

### DIFF
--- a/lua/dap-view/highlight.lua
+++ b/lua/dap-view/highlight.lua
@@ -5,7 +5,7 @@ local api = vim.api
 ---@param name string
 ---@param link string
 local hl_create = function(name, link)
-    api.nvim_set_hl(0, globals.HL_PREFIX .. name, { link = link })
+    api.nvim_set_hl(0, globals.HL_PREFIX .. name, { default = true, link = link })
 end
 
 local define_base_links = function()


### PR DESCRIPTION
Don't override existing definition by using `nvim_set_hl` default options. This fixes issues depending on load order of themes and style adjustments and the actual `dap-view` plugin setup by only setting highlight groups in `dap-view` whenever they don't exist yet. This allows users to override specific groups on demand and no matter in which order the adjustments, themes and plugins are loaded, the user's custom override will be preserved instead of overwriting them with `dap-view` default definitions.

Related: https://neovim.io/doc/user/api.html#nvim_set_hl()
Related: https://neovim.io/doc/user/syntax.html#%3Ahi-default