### PR TITLE
docs: update URL to nvim-dap-disasm

### DIFF
--- a/docs/src/routes/custom-views/+page.md
+++ b/docs/src/routes/custom-views/+page.md
@@ -56,4 +56,4 @@ return {
 
 ### Register View
 
-If you are a plugin author, you can use the `register_view` function to ensure your view is loaded. By doing that, users don't have to create the custom view "manually". An example can be found [here](https://github.com/Jorenar/nvim-dap-disasm/blob/543939e2572c4291f1978737d687977385a9e669/lua/dap-disasm.lua#L347-L355).
+If you are a plugin author, you can use the `register_view` function to ensure your view is loaded. By doing that, users don't have to create the custom view "manually". An example can be found [here](https://codeberg.org/Jorenar/nvim-dap-disasm/src/commit/fb2dc2c5fb19cac8bc642f0c411d57cc14e99cc0/lua/dap-disasm.lua#L378-L385).

--- a/docs/src/routes/disassembly/+page.md
+++ b/docs/src/routes/disassembly/+page.md
@@ -4,7 +4,7 @@ title: Disassembly View
 
 <img src="https://github.com/user-attachments/assets/97ed9e8c-20a0-4355-bb00-5199c7b3cd59" alt="disassembly view" />
 
-The disassembly view is a [custom view](custom-views), built on top of [nvim-dap-disasm](https://github.com/Jorenar/nvim-dap-disasm). To enable it, **you need to install nvim-dap-disasm**. After installing the extension, add it to your `winbar.sections` table:
+The disassembly view is a [custom view](custom-views), built on top of [nvim-dap-disasm](https://codeberg.org/Jorenar/nvim-dap-disasm). To enable it, **you need to install nvim-dap-disasm**. After installing the extension, add it to your `winbar.sections` table:
 
 ```lua
 return {
@@ -24,7 +24,7 @@ If using `lazy.nvim` (or any means of lazy loading, in general), make sure to ad
 ```lua
 return {
     {
-        "Jorenar/nvim-dap-disasm",
+        url = "https://codeberg.org/Jorenar/nvim-dap-disasm.git",
         dependencies = "igorlfs/nvim-dap-view",
         config = true,
     },

--- a/docs/src/routes/home/+page.md
+++ b/docs/src/routes/home/+page.md
@@ -104,7 +104,7 @@ You can also write [your own](custom-views) views.
 
 #### Disassembly view
 
-A custom view is used to power the [disassembly view](disassembly), an integration with [nvim-dap-disasm](https://github.com/Jorenar/nvim-dap-disasm).
+A custom view is used to power the [disassembly view](disassembly), an integration with [nvim-dap-disasm](https://codeberg.org/Jorenar/nvim-dap-disasm).
 
 <img src="https://github.com/user-attachments/assets/97ed9e8c-20a0-4355-bb00-5199c7b3cd59" alt="disassembly view" />
 


### PR DESCRIPTION
Hi! I've moved the [nvim-dap-disasm](https://codeberg.org/Jorenar/nvim-dap-disasm) to Codeberg (with GitHub being a mirror)