### PR TITLE
fix: guard readOnly dim highlight for unknown variable types

### DIFF
--- a/lua/dap-view/util/hl.lua
+++ b/lua/dap-view/util/hl.lua
@@ -48,6 +48,7 @@ M.hl_from_variable = function(v)
 
     if
         globals.HAS_0_12
+        and hl
         and v.presentationHint
         and vim.tbl_contains(v.presentationHint.attributes or {}, "readOnly")
     then


### PR DESCRIPTION
Fixes a render crash in `hl_from_variable()`.

If an adapter returns `presentationHint.attributes = { "readOnly" }` for a variable/evaluate response without a recognized `type`, `hl` remains `nil` and the code attempts to concatenate `"Dim"`.

This aborts Scopes/Watches rendering after the winbar has already switched tabs, which can leave stale previous view content visible.

This patch only appends `"Dim"` when a highlight group was actually resolved.

Related: #166
