### PR TITLE
feat(keymaps): add descriptions to winbar keymaps

### DIFF
--- a/lua/dap-view/options/winbar/init.lua
+++ b/lua/dap-view/options/winbar/init.lua
@@ -106,9 +106,12 @@ M.set_action_keymaps = function(bufnr)
                 vim.notify_once("View '" .. view .. "' not found, skipping setup", log.WARN)
                 winbar.sections[k] = nil
             else
+                local label = type(section.label) == "string" and section.label or nil
+                ---@cast label string?
+
                 vim.keymap.set("n", section.keymap, function()
                     M.wrapped_action(view)
-                end, { buffer = bufnr or state.bufnr })
+                end, { buffer = bufnr or state.bufnr, desc = label })
             end
         end
     end

--- a/lua/dap-view/options/winbar/init.lua
+++ b/lua/dap-view/options/winbar/init.lua
@@ -99,6 +99,8 @@ M.set_action_keymaps = function(bufnr)
     if bufnr or state.bufnr then
         local winbar = setup.config.winbar
 
+        local win_width = api.nvim_win_get_width(state.winnr)
+
         for k, view in pairs(winbar.sections) do
             local section = winbar.custom_sections[view] or winbar.base_sections[view]
 
@@ -106,12 +108,14 @@ M.set_action_keymaps = function(bufnr)
                 vim.notify_once("View '" .. view .. "' not found, skipping setup", log.WARN)
                 winbar.sections[k] = nil
             else
-                local label = type(section.label) == "string" and section.label or nil
-                ---@cast label string?
+                local desc = type(section.label) == "function" and section.label(win_width, state.current_section)
+                    or section.label
+
+                ---@cast desc string
 
                 vim.keymap.set("n", section.keymap, function()
                     M.wrapped_action(view)
-                end, { buffer = bufnr or state.bufnr, desc = label })
+                end, { buffer = bufnr or state.bufnr, desc = desc })
             end
         end
     end


### PR DESCRIPTION
Thank you for closing #164, but it looks like descriptions for the winbar keymaps were not covered.

I didn't know this originally, but the `label` field can also be a function. I wasn't sure of the best way to handle that case, so I just left that as `nil`. Feel free to correct this as needed.