### PR TITLE
fix: Change key 'buf' to 'buffer'; Close #184

### DIFF
--- a/lua/dap-view/console/keymaps.lua
+++ b/lua/dap-view/console/keymaps.lua
@@ -4,17 +4,17 @@ local keymap = require("dap-view.views.keymaps.util").keymap
 
 local M = {}
 
----@param buf integer
-M.set_keymaps = function(buf)
+---@param buffer integer
+M.set_keymaps = function(buffer)
     local keys = setup.config.keymaps.console
 
     keymap(keys.next_session, function()
         require("dap-view").navigate({ count = vim.v.count1, wrap = true, type = "sessions" })
-    end, { buf = buf, desc = "go to next session" })
+    end, { buffer = buffer, desc = "go to next session" })
 
     keymap(keys.prev_session, function()
         require("dap-view").navigate({ count = -vim.v.count1, wrap = true, type = "sessions" })
-    end, { buf = buf, desc = "go to prev session" })
+    end, { buffer = buffer, desc = "go to prev session" })
 end
 
 return M

--- a/lua/dap-view/hover/init.lua
+++ b/lua/dap-view/hover/init.lua
@@ -31,11 +31,11 @@ M.set_buf_options = function(bufnr)
     buf.filetype = "dap-view-hover"
 end
 
----@param buf integer
-M.set_keymaps = function(buf)
+---@param buffer integer
+M.set_keymaps = function(buffer)
     local keys = setup.config.keymaps.hover
 
-    keymap(keys.quit, "<C-w>q", { buf = buf, desc = "close" })
+    keymap(keys.quit, "<C-w>q", { buffer = buffer, desc = "close" })
 
     keymap(keys.toggle, function()
         local cursor_line = api.nvim_win_get_cursor(state.hover_winnr)[1]
@@ -44,19 +44,19 @@ M.set_keymaps = function(buf)
             if require("dap-view.hover.actions").expand_or_collapse(cursor_line) then
                 require("dap-view.hover.eval").evaluate_expression(state.hover)
 
-                local line, width = unpack(require("dap-view.hover.view").show(buf))
+                local line, width = unpack(require("dap-view.hover.view").show(buffer))
 
                 api.nvim_win_set_height(state.hover_winnr, line)
                 api.nvim_win_set_width(state.hover_winnr, width)
             end
         end)()
-    end, { buf = buf, desc = "toggle" })
+    end, { buffer = buffer, desc = "toggle" })
 
     keymap(keys.jump_to_parent, function()
         local cursor_line = api.nvim_win_get_cursor(state.hover_winnr)[1]
 
         require("dap-view.hover.actions").jump_to_parent(cursor_line)
-    end, { buf = buf, desc = "jump to parent" })
+    end, { buffer = buffer, desc = "jump to parent" })
 
     keymap(keys.set_value, function()
         local cursor_line = api.nvim_win_get_cursor(state.hover_winnr)[1]
@@ -66,13 +66,13 @@ M.set_keymaps = function(buf)
                 -- This is a little redundant
                 require("dap-view.hover.eval").evaluate_expression(state.hover)
 
-                local line, width = unpack(require("dap-view.hover.view").show(buf))
+                local line, width = unpack(require("dap-view.hover.view").show(buffer))
 
                 api.nvim_win_set_height(state.hover_winnr, line)
                 api.nvim_win_set_width(state.hover_winnr, width)
             end
         end)()
-    end, { buf = buf, desc = "set value" })
+    end, { buffer = buffer, desc = "set value" })
 end
 
 ---@param bufnr integer

--- a/lua/dap-view/views/keymaps/help.lua
+++ b/lua/dap-view/views/keymaps/help.lua
@@ -79,7 +79,7 @@ M.show_help = function()
 
     keymap(setup.config.keymaps.help.quit, function()
         api.nvim_win_close(help_win, true)
-    end, { buf = help_buf, desc = "close" })
+    end, { buffer = help_buf, desc = "close" })
 
     util.set_lines(help_buf, 0, -1, true, split_content)
 

--- a/lua/dap-view/views/keymaps/init.lua
+++ b/lua/dap-view/views/keymaps/init.lua
@@ -5,29 +5,29 @@ local keymap = require("dap-view.views.keymaps.util").keymap
 
 local M = {}
 
----@param buf integer?
-M.set_keymaps = function(buf)
+---@param buffer integer?
+M.set_keymaps = function(buffer)
     local keys = setup.config.keymaps.base
 
     keymap(keys.next_view, function()
         require("dap-view").navigate({ count = vim.v.count1, wrap = true })
-    end, { buf = buf, desc = "go to next view" })
+    end, { buffer = buffer, desc = "go to next view" })
 
     keymap(keys.prev_view, function()
         require("dap-view").navigate({ count = -vim.v.count1, wrap = true })
-    end, { buf = buf, desc = "go to prev view" })
+    end, { buffer = buffer, desc = "go to prev view" })
 
     keymap(keys.jump_to_last, function()
         require("dap-view").navigate({ count = vim._maxint, wrap = false })
-    end, { buf = buf, desc = "jump to last view" })
+    end, { buffer = buffer, desc = "jump to last view" })
 
     keymap(keys.jump_to_first, function()
         require("dap-view").navigate({ count = -vim._maxint, wrap = false })
-    end, { buf = buf, desc = "jump to first view" })
+    end, { buffer = buffer, desc = "jump to first view" })
 
     keymap(keys.help, function()
         help.show_help()
-    end, { buf = buf, desc = "show help" })
+    end, { buffer = buffer, desc = "show help" })
 end
 
 return M

--- a/lua/dap-view/views/keymaps/util.lua
+++ b/lua/dap-view/views/keymaps/util.lua
@@ -14,7 +14,7 @@ function M.keymap(lhs, rhs, opts, mode)
 
     opts = opts or {}
     opts.nowait = true
-    opts.buf = opts.buf or state.bufnr
+    opts.buffer = opts.buffer or state.bufnr
 
     for _, v in ipairs(lhs) do
         vim.keymap.set(mode, v, rhs, opts)
@@ -31,7 +31,7 @@ function M.keymap_del(lhs, opts, mode)
     end
 
     opts = opts or {}
-    opts.buf = opts.buf or state.bufnr
+    opts.buffer = opts.buffer or state.bufnr
 
     for _, v in ipairs(lhs) do
         vim.keymap.del(mode, v, opts)

--- a/lua/dap-view/views/util.lua
+++ b/lua/dap-view/views/util.lua
@@ -102,7 +102,7 @@ M.set_keymaps = function(view)
         require("dap-view.views.keymaps.util").keymap(
             key,
             keymaps[k].action,
-            { buf = state.bufnr, desc = keymaps[k].desc }
+            { buffer = state.bufnr, desc = keymaps[k].desc }
         )
     end
 end


### PR DESCRIPTION
s. #184 for all information.

This PR basically changes every occurrence of the key `buf` in a table (often called `opts`) submitted to (occasionally by intermediates/proxy functions)

https://github.com/PhilippFeO/nvim-dap-view/blob/b77d5a69cc9b7cb4cdb346cd891cd7464dceaf6b/lua/dap-view/views/keymaps/util.lua#L9-L22

and

https://github.com/PhilippFeO/nvim-dap-view/blob/b77d5a69cc9b7cb4cdb346cd891cd7464dceaf6b/lua/dap-view/views/keymaps/util.lua#L27-L39

to fix #184.

---

Close #184