### PR TITLE
fix(hover): disable sign column in hover window

### DIFF
--- a/lua/dap-view/hover/init.lua
+++ b/lua/dap-view/hover/init.lua
@@ -16,6 +16,7 @@ M.set_win_options = function(winnr)
     win.foldcolumn = "0"
     win.number = false
     win.relativenumber = false
+    win.signcolumn = "no"
 
     -- If not focused, NormalFloat won't be applied right away
     win.winhighlight = "Normal:NormalFloat"


### PR DESCRIPTION
When signcolumn is enabled, the window width does not correspond to the width of the text displayed.
This PR sets signcolumn to false by default.

Before:
<img width="234" height="113" alt="image" src="https://github.com/user-attachments/assets/8a061c38-007d-4f0a-965b-683d0da40959" />
 After:
<img width="244" height="83" alt="image" src="https://github.com/user-attachments/assets/14bd1150-2d59-498b-aec9-0ef32a72aa7c" />
